### PR TITLE
Qat reform

### DIFF
--- a/QSQL/CMakeLists.txt
+++ b/QSQL/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Set up the project.
 cmake_minimum_required( VERSION 3.10 )
-set  (CMAKE_CXX_STANDARD 17)
+set  (CMAKE_CXX_STANDARD 20)
 project( "QSQLite" VERSION 3.0.3 LANGUAGES CXX )
 set    ( CMAKE_BUILD_TYPE RelWithDebInfo )
 

--- a/QatDataAnalysis/CMakeLists.txt
+++ b/QatDataAnalysis/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(QatDataAnalysis VERSION ${Qat_VERSION} LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file( GLOB SOURCES src/*.cpp )

--- a/QatDataModeling/CMakeLists.txt
+++ b/QatDataModeling/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(QatDataModeling VERSION ${Qat_VERSION} LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file( GLOB SOURCES src/*.cpp Minuit2/src/*.cxx)

--- a/QatGenericFunctions/CMakeLists.txt
+++ b/QatGenericFunctions/CMakeLists.txt
@@ -4,6 +4,7 @@ project(QatGenericFunctions VERSION ${Qat_VERSION} LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_BUILD_TYPE Release)
 
 file( GLOB SOURCES src/*.cpp )
 file( GLOB HEADERS QatGenericFunctions/*.h QatGenericFunctions/*.icc )

--- a/QatGenericFunctions/CMakeLists.txt
+++ b/QatGenericFunctions/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(QatGenericFunctions VERSION ${Qat_VERSION} LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_BUILD_TYPE Debug)
 
 file( GLOB SOURCES src/*.cpp )
 file( GLOB HEADERS QatGenericFunctions/*.h QatGenericFunctions/*.icc )

--- a/QatGenericFunctions/QatGenericFunctions/AbsFunction.h
+++ b/QatGenericFunctions/QatGenericFunctions/AbsFunction.h
@@ -28,7 +28,7 @@
 #ifndef AbsFunction_h
 #define AbsFunction_h 1
 #include "QatGenericFunctions/Argument.h"
-
+#include <memory>
 namespace Genfun {
 
   class AbsParameter;

--- a/QatGenericFunctions/QatGenericFunctions/AbsParameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/AbsParameter.h
@@ -28,7 +28,7 @@
 //--------------------------------------------------------------------//
 #ifndef _AbsParameter_h_
 #define _AbsParameter_h_
-
+#include <memory>
 namespace Genfun {
   class Parameter;
   class ParameterSum;

--- a/QatGenericFunctions/QatGenericFunctions/AssociatedLaguerrePolynomial.h
+++ b/QatGenericFunctions/QatGenericFunctions/AssociatedLaguerrePolynomial.h
@@ -29,7 +29,6 @@
 #ifndef AssociatedLaguerrePolynomial_h
 #define AssociatedLaguerrePolynomial_h 1
 #include "QatGenericFunctions/AbsFunction.h"
-#include "QatGenericFunctions/Parameter.h"
 #include "QatGenericFunctions/Defs.h"
 namespace Genfun {
 

--- a/QatGenericFunctions/QatGenericFunctions/AssociatedLaguerrePolynomial.icc
+++ b/QatGenericFunctions/QatGenericFunctions/AssociatedLaguerrePolynomial.icc
@@ -87,11 +87,13 @@ namespace Genfun {
 	-AssociatedLaguerrePolynomial(_n-1,_a+1,STD)
 	:
 	-(AssociatedLaguerrePolynomial(_n-1,_a+1,STD)/exp(0.5*(lgamma(_n+_a+1)-lgamma(_n+1))));
-      return Derivative(& fPrime);
+      std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+      return Derivative(deriv);
     }
     else {
       const AbsFunction & fPrime   = FixedConstant(0.0);
-      return Derivative(& fPrime);
+      std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+      return Derivative(deriv);
     }
   }
 } // end namespace Genfun

--- a/QatGenericFunctions/QatGenericFunctions/AssociatedLegendre.h
+++ b/QatGenericFunctions/QatGenericFunctions/AssociatedLegendre.h
@@ -29,7 +29,6 @@
 #ifndef AssociatedLegendre_h
 #define AssociatedLegendre_h 1
 #include "QatGenericFunctions/AbsFunction.h"
-#include "QatGenericFunctions/Parameter.h"
 #include "QatGenericFunctions/Defs.h"
 namespace Genfun {
 

--- a/QatGenericFunctions/QatGenericFunctions/Bessel.h
+++ b/QatGenericFunctions/QatGenericFunctions/Bessel.h
@@ -83,7 +83,7 @@ namespace FractionalOrder {
 
     // The type and order of the Bessel function
     Type      _type;
-    Parameter _n; // the fractional order:
+    const std::shared_ptr<Parameter> _n; // the fractional order:
   
   };
 } // namespace FractionalOrder

--- a/QatGenericFunctions/QatGenericFunctions/Bessel.icc
+++ b/QatGenericFunctions/QatGenericFunctions/Bessel.icc
@@ -234,7 +234,9 @@ double Bessel::operator() (double x) const {
     FM.n().setValue(n().getValue()-1);
     const AbsFunction & fPrime =   (_type==FirstKind || _type==SecondKind) ? 0.5*(FM-FP) :
       _type==ModifiedFirstKind ? 0.5*(FM+FP) : _type==ModifiedSecondKind ? -0.5*(FM+FP) : 0.5*FixedConstant(0.0);
-    return Derivative(& fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
+
   }
 
 

--- a/QatGenericFunctions/QatGenericFunctions/Bessel.icc
+++ b/QatGenericFunctions/QatGenericFunctions/Bessel.icc
@@ -153,7 +153,7 @@ FUNCTION_OBJECT_IMP_INLINE(Bessel)
 inline
 Bessel::Bessel(Type type):
   _type(type),
-  _n("N", 0.0,-10,10)
+  _n(new Parameter("N", 0.0,-10,10))
 {
 }
 
@@ -171,12 +171,12 @@ Bessel::Bessel(const Bessel & right):
 
 inline
 Parameter & Bessel::n() {
-  return _n;
+  return *_n;
 }
 
 inline
 const Parameter & Bessel::n() const {
-  return _n;
+  return *_n;
 }
 
 
@@ -184,7 +184,7 @@ inline
 double Bessel::operator() (double x) const {
   gsl_sf_result result;
   if (_type==FirstKind) {
-    int status = gsl_sf_bessel_Jnu_e(_n.getValue(), x,  &result);
+    int status = gsl_sf_bessel_Jnu_e(n().getValue(), x,  &result);
     if (status!=0) {
       std::cerr << "Warning, GSL function gsl_sf_bessel_Jnu_impl" 
 		<< " return code " << status << std::endl;
@@ -193,7 +193,7 @@ double Bessel::operator() (double x) const {
     return result.val;
   }
   else if (_type==SecondKind) {
-    int status = gsl_sf_bessel_Ynu_e(_n.getValue(), x,  &result);
+    int status = gsl_sf_bessel_Ynu_e(n().getValue(), x,  &result);
     if (status!=0) {
       std::ostringstream stream;
       stream << "Warning, GSL function gsl_sf_bessel_Ynu_impl" 
@@ -203,7 +203,7 @@ double Bessel::operator() (double x) const {
     return result.val;
   }
   else if (_type==ModifiedFirstKind) {
-    int status = gsl_sf_bessel_Inu_e(_n.getValue(), x,  &result);
+    int status = gsl_sf_bessel_Inu_e(n().getValue(), x,  &result);
     if (status!=0) {
       std::ostringstream stream;
       stream << "Warning, GSL function gsl_sf_bessel_Inu_impl" 
@@ -213,7 +213,7 @@ double Bessel::operator() (double x) const {
     return result.val;
   }
   else if (_type==ModifiedSecondKind) {
-    int status = gsl_sf_bessel_Knu_e(_n.getValue(), x,  &result);
+    int status = gsl_sf_bessel_Knu_e(n().getValue(), x,  &result);
     if (status!=0) {
       std::ostringstream stream;
       stream << "Warning, GSL function gsl_sf_bessel_Knu_impl" 

--- a/QatGenericFunctions/QatGenericFunctions/Bessel.icc
+++ b/QatGenericFunctions/QatGenericFunctions/Bessel.icc
@@ -103,37 +103,44 @@ namespace Genfun {
       if (_n==0) {
 	if (_type==FirstKind || _type==SecondKind || _type==ModifiedSecondKind) {
 	  const AbsFunction & fPrime =  -Bessel(_n+1,_type);
-	  return Derivative(& fPrime);
+	  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+	  return Derivative(deriv);
 	}
 	else if (_type==ModifiedFirstKind) {
 	  const AbsFunction & fPrime =  Bessel(_n+1,_type);
-	  return Derivative(& fPrime);
+	  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+	  return Derivative(deriv);
 	}
 	else {
           // Should never happen. 
           throw std::logic_error("Bessel::Unknown type");	
 	  const AbsFunction & fPrime=FixedConstant(0.0);
-	  return Derivative(& fPrime);	
+	  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+	  return Derivative(deriv);	
         }
       }
       else {
 	if (_type==FirstKind || _type==SecondKind) {
 	  const AbsFunction & fPrime =  0.5*(Bessel(_n-1, _type)-Bessel(_n+1,_type));
-	  return Derivative(& fPrime);
+	  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+	  return Derivative(deriv);
 	}
 	else if (_type==ModifiedFirstKind) {
 	  const AbsFunction & fPrime =  0.5*(Bessel(_n-1, _type)+Bessel(_n+1,_type));
-	  return Derivative(& fPrime);
+	  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+	  return Derivative(deriv);
 	}
 	else if (_type==ModifiedSecondKind) { 
 	  const AbsFunction & fPrime =  -0.5*(Bessel(_n-1, _type)+Bessel(_n+1,_type));
-	  return Derivative(& fPrime);
+	  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+	  return Derivative(deriv);
 	}
 	else {
           // Should never happen. 
           throw std::logic_error("Bessel::Unknown type");	
 	  const AbsFunction & fPrime=FixedConstant(0.0);
-	  return Derivative(& fPrime);	
+	  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+	  return Derivative(deriv);	
 	}
       }
     }

--- a/QatGenericFunctions/QatGenericFunctions/BetaDistribution.h
+++ b/QatGenericFunctions/QatGenericFunctions/BetaDistribution.h
@@ -65,8 +65,8 @@ namespace Genfun {
     
     // Here are the two parameters alpha and beta:
     
-    Parameter _alpha;
-    Parameter _beta;
+    std::shared_ptr<Parameter> _alpha;
+    std::shared_ptr<Parameter> _beta;
     
     
   };

--- a/QatGenericFunctions/QatGenericFunctions/ConstMinusFunction.h
+++ b/QatGenericFunctions/QatGenericFunctions/ConstMinusFunction.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ConstMinusFunction(double constant, const AbsFunction *arg);
+    ConstMinusFunction(double constant, const std::shared_ptr<const AbsFunction> & arg);
   
     // Copy constructor
     ConstMinusFunction(const ConstMinusFunction &right);
@@ -66,7 +66,7 @@ namespace Genfun {
     const ConstMinusFunction & operator=(const ConstMinusFunction &right);
 
     double             _constant;
-    const AbsFunction *_arg;
+    std::shared_ptr<const AbsFunction> _arg;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ConstMinusParameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/ConstMinusParameter.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ConstMinusParameter(double, const AbsParameter *);
+    ConstMinusParameter(double, const std::shared_ptr<const AbsParameter> & );
   
     // Copy constructor
     ConstMinusParameter(const ConstMinusParameter &right);
@@ -56,7 +56,7 @@ namespace Genfun {
     const ConstMinusParameter & operator=(const ConstMinusParameter &right);
 
     double        _constant;
-    AbsParameter *_parameter;
+    std::shared_ptr<const AbsParameter> _parameter;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ConstOverFunction.h
+++ b/QatGenericFunctions/QatGenericFunctions/ConstOverFunction.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ConstOverFunction(double constant, const AbsFunction *arg);
+    ConstOverFunction(double constant, const std::shared_ptr<const AbsFunction> & arg);
   
     // Copy constructor
     ConstOverFunction(const ConstOverFunction &right);
@@ -66,7 +66,7 @@ namespace Genfun {
     const ConstOverFunction & operator=(const ConstOverFunction &right);
 
     double             _constant;
-    const AbsFunction *_arg;
+    std::shared_ptr<const AbsFunction> _arg;
   };
 } // namespace Genfun
 

--- a/QatGenericFunctions/QatGenericFunctions/ConstOverParameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/ConstOverParameter.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ConstOverParameter(double, const AbsParameter *);
+    ConstOverParameter(double, const std::shared_ptr<const AbsParameter> & );
   
     // Copy constructor
     ConstOverParameter(const ConstOverParameter &right);
@@ -56,7 +56,7 @@ namespace Genfun {
     const ConstOverParameter & operator=(const ConstOverParameter &right);
 
     double        _constant;
-    AbsParameter *_parameter;
+    std::shared_ptr<const AbsParameter> _parameter;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ConstPlusFunction.h
+++ b/QatGenericFunctions/QatGenericFunctions/ConstPlusFunction.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ConstPlusFunction(double constant, const AbsFunction *arg);
+    ConstPlusFunction(double constant, const std::shared_ptr<const AbsFunction> & arg);
   
     // Copy constructor
     ConstPlusFunction(const ConstPlusFunction &right);
@@ -66,7 +66,7 @@ namespace Genfun {
     const ConstPlusFunction & operator=(const ConstPlusFunction &right);
 
     double             _constant;
-    const AbsFunction *_arg;
+    std::shared_ptr<const AbsFunction> _arg;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ConstPlusParameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/ConstPlusParameter.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ConstPlusParameter(double, const AbsParameter *);
+    ConstPlusParameter(double, const std::shared_ptr<const AbsParameter> & );
   
     // Copy constructor
     ConstPlusParameter(const ConstPlusParameter &right);
@@ -56,7 +56,7 @@ namespace Genfun {
     const ConstPlusParameter & operator=(const ConstPlusParameter &right);
 
     double        _constant;
-    AbsParameter *_parameter;
+    std::shared_ptr<const AbsParameter>  _parameter;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ConstTimesFunction.h
+++ b/QatGenericFunctions/QatGenericFunctions/ConstTimesFunction.h
@@ -38,7 +38,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ConstTimesFunction(double constant, const AbsFunction *arg);
+    ConstTimesFunction(double constant, const std::shared_ptr<const AbsFunction>  & arg);
   
     // Copy constructor
     ConstTimesFunction(const ConstTimesFunction &right);
@@ -65,7 +65,7 @@ namespace Genfun {
     const ConstTimesFunction & operator=(const ConstTimesFunction &right);
 
     double             _constant;
-    const AbsFunction *_arg;
+    std::shared_ptr<const AbsFunction> _arg;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ConstTimesParameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/ConstTimesParameter.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ConstTimesParameter(double, const AbsParameter *);
+    ConstTimesParameter(double, const std::shared_ptr<const AbsParameter> & );
   
     // Copy constructor
     ConstTimesParameter(const ConstTimesParameter &right);
@@ -56,7 +56,7 @@ namespace Genfun {
     const ConstTimesParameter & operator=(const ConstTimesParameter &right);
 
     double        _constant;
-    AbsParameter *_parameter;
+    std::shared_ptr<const AbsParameter> _parameter;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/CumulativeChiSquare.h
+++ b/QatGenericFunctions/QatGenericFunctions/CumulativeChiSquare.h
@@ -63,7 +63,7 @@ namespace Genfun {
     unsigned int _nDof;
   
     // Here is the "work function"
-    const AbsFunction *_function;
+    std::shared_ptr<const AbsFunction> _function;
 
     // This function is needed in all constructors:
     void create(); 

--- a/QatGenericFunctions/QatGenericFunctions/CumulativeChiSquare.icc
+++ b/QatGenericFunctions/QatGenericFunctions/CumulativeChiSquare.icc
@@ -41,13 +41,13 @@ AbsFunction(),
 
 inline
 CumulativeChiSquare::~CumulativeChiSquare() {
-  delete _function;
 }
 
 inline
 CumulativeChiSquare::CumulativeChiSquare(const CumulativeChiSquare & right):
 AbsFunction(right),
-_nDof(right._nDof)
+_nDof(right._nDof),
+_function(right._function)
 {
   create();
 }
@@ -67,6 +67,6 @@ void CumulativeChiSquare::create() {
   Variable x;
   IncompleteGamma incompleteGamma(IncompleteGamma::P);
   incompleteGamma.a().setValue(_nDof/2.0);
-  _function = (incompleteGamma(x/2.0)).clone();
+  _function = std::shared_ptr<const AbsFunction>(incompleteGamma(x/2.0).clone());
 } 
 } // namespace Genfun

--- a/QatGenericFunctions/QatGenericFunctions/FunctionComposition.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionComposition.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
 
     // Constructor
-    FunctionComposition(const AbsFunction *arg1, const AbsFunction *arg2);
+    FunctionComposition(const std::shared_ptr<const AbsFunction> & arg1, const std::shared_ptr<const AbsFunction> & arg2);
 
     // Copy constructor
     FunctionComposition(const FunctionComposition &right);
@@ -65,8 +65,8 @@ namespace Genfun {
     // It is illegal to assign a FunctionComposition
     const FunctionComposition & operator=(const FunctionComposition &right);
 
-    const AbsFunction *_arg1;
-    const AbsFunction *_arg2;  
+    std::shared_ptr<const AbsFunction>  _arg1;
+    std::shared_ptr<const AbsFunction>  _arg2;  
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/FunctionDifference.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionDifference.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
 
     // Constructor
-    FunctionDifference(const AbsFunction* arg1, const AbsFunction *arg2);
+    FunctionDifference(const std::shared_ptr<const AbsFunction> & arg1, const std::shared_ptr<const AbsFunction> & arg2);
   
     // Copy constructor
     FunctionDifference(const FunctionDifference &right);
@@ -65,8 +65,8 @@ namespace Genfun {
     // It is illegal to assign a FunctionDifference
     const FunctionDifference & operator=(const FunctionDifference &right);
 
-    const AbsFunction *_arg1;
-    const AbsFunction *_arg2;
+    std::shared_ptr<const AbsFunction> _arg1;
+    std::shared_ptr<const AbsFunction> _arg2;
 
   };
 } // namespace Genfun

--- a/QatGenericFunctions/QatGenericFunctions/FunctionNegation.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionNegation.h
@@ -38,7 +38,7 @@ namespace Genfun {
       public:
 
     // Constructor
-    FunctionNegation(const AbsFunction *arg1);
+    FunctionNegation(const std::shared_ptr<const AbsFunction> &arg1);
   
     // Copy constructor.
     FunctionNegation(const FunctionNegation &right);
@@ -65,7 +65,7 @@ namespace Genfun {
     const FunctionNegation & operator=(const FunctionNegation &right);
 
     // The function we're negating.  
-    const AbsFunction *_arg1;
+    std::shared_ptr<const AbsFunction> _arg1;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/FunctionNoop.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionNoop.h
@@ -38,7 +38,7 @@ namespace Genfun {
       public:
 
     // Constructor
-    FunctionNoop(const AbsFunction *arg1);
+    FunctionNoop(const std::shared_ptr<const AbsFunction> & arg1);
   
     // Copy constructor.
     FunctionNoop(const FunctionNoop &right);
@@ -65,7 +65,7 @@ namespace Genfun {
     const FunctionNoop & operator=(const FunctionNoop &right);
 
     // The function we're negating.  
-    const AbsFunction *_arg1;
+    std::shared_ptr<const AbsFunction>  _arg1;
 
  };
 } // namespace Genfun

--- a/QatGenericFunctions/QatGenericFunctions/FunctionNumDeriv.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionNumDeriv.h
@@ -38,7 +38,7 @@ namespace Genfun {
       public:
 
     // Constructor
-    FunctionNumDeriv(const AbsFunction *arg1, unsigned int index=0);
+    FunctionNumDeriv(const std::shared_ptr<const AbsFunction> & arg1, unsigned int index=0);
   
     // Copy constructor.
     FunctionNumDeriv(const FunctionNumDeriv &right);
@@ -59,7 +59,7 @@ namespace Genfun {
     const FunctionNumDeriv & operator=(const FunctionNumDeriv &right);
 
     // The function we're differntiating.
-    const AbsFunction        *_arg1;
+    std::shared_ptr<const AbsFunction>       _arg1;
     const unsigned int       _wrtIndex;
 
     // helper data and methods to let us code Argument and double similarly

--- a/QatGenericFunctions/QatGenericFunctions/FunctionPlusParameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionPlusParameter.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
     
     // Constructor
-    FunctionPlusParameter(const AbsParameter *parameter, const AbsFunction *function);
+    FunctionPlusParameter(const std::shared_ptr<const AbsParameter> & parameter, const AbsFunction *function);
   
     // Copy constructor
     FunctionPlusParameter(const FunctionPlusParameter &right);
@@ -66,7 +66,7 @@ namespace Genfun {
     const FunctionPlusParameter & operator=(const FunctionPlusParameter &right);
 
     const AbsFunction  *_function;
-    AbsParameter       *_parameter;
+    std::shared_ptr<const AbsParameter>  _parameter;
 
   };
 } // namespace Genfun

--- a/QatGenericFunctions/QatGenericFunctions/FunctionPlusParameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionPlusParameter.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
     
     // Constructor
-    FunctionPlusParameter(const std::shared_ptr<const AbsParameter> & parameter, const AbsFunction *function);
+    FunctionPlusParameter(const std::shared_ptr<const AbsParameter> & parameter, const std::shared_ptr<const AbsFunction> & function);
   
     // Copy constructor
     FunctionPlusParameter(const FunctionPlusParameter &right);
@@ -65,7 +65,7 @@ namespace Genfun {
     // It is illegal to assign a FunctionPlusParameter
     const FunctionPlusParameter & operator=(const FunctionPlusParameter &right);
 
-    const AbsFunction  *_function;
+    std::shared_ptr<const AbsFunction>   _function;
     std::shared_ptr<const AbsParameter>  _parameter;
 
   };

--- a/QatGenericFunctions/QatGenericFunctions/FunctionProduct.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionProduct.h
@@ -38,7 +38,7 @@ namespace Genfun {
       public:
 
     // Constructor
-    FunctionProduct(const AbsFunction *arg1, const AbsFunction *arg2);
+    FunctionProduct(const std::shared_ptr<const AbsFunction> & arg1, const std::shared_ptr<const AbsFunction> & arg2);
 
     // Copy constructor
     FunctionProduct(const FunctionProduct &right);
@@ -64,8 +64,8 @@ namespace Genfun {
     // It is illegal to assign a FunctionProduct
     const FunctionProduct & operator=(const FunctionProduct &right);
 
-    const AbsFunction *_arg1;
-    const AbsFunction *_arg2;  
+    std::shared_ptr<const AbsFunction>  _arg1;
+    std::shared_ptr<const AbsFunction>  _arg2;  
   };
 } // namespace Genfun
 

--- a/QatGenericFunctions/QatGenericFunctions/FunctionQuotient.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionQuotient.h
@@ -38,7 +38,7 @@ namespace Genfun {
       public:
 
     // Constructor
-    FunctionQuotient(const AbsFunction *arg1, const AbsFunction *arg2);
+    FunctionQuotient(const std::shared_ptr<const AbsFunction> & arg1, const std::shared_ptr<const AbsFunction> & arg2);
 
     // Copy constructor
     FunctionQuotient(const FunctionQuotient &right);
@@ -64,8 +64,8 @@ namespace Genfun {
     // It is illegal to assign a FunctionQuotient
     const FunctionQuotient & operator=(const FunctionQuotient &right);
   
-    const AbsFunction *_arg1;
-    const AbsFunction *_arg2;
+    std::shared_ptr<const AbsFunction>  _arg1;
+    std::shared_ptr<const AbsFunction>  _arg2;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/FunctionSum.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionSum.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    FunctionSum(const AbsFunction *arg1, const AbsFunction *arg2);
+    FunctionSum(const std::shared_ptr<const AbsFunction> & arg1, const std::shared_ptr<const AbsFunction> & arg2);
   
     // Copy constructor
     FunctionSum(const FunctionSum &right);
@@ -65,8 +65,8 @@ namespace Genfun {
     // It is illegal to assign a FunctionSum
     const FunctionSum & operator=(const FunctionSum &right);
 
-    const AbsFunction *_arg1;
-    const AbsFunction *_arg2;
+    std::shared_ptr<const AbsFunction>  _arg1;
+    std::shared_ptr<const AbsFunction>  _arg2;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/FunctionTimesParameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionTimesParameter.h
@@ -40,7 +40,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    FunctionTimesParameter(const AbsParameter *parameter, const AbsFunction *function);
+    FunctionTimesParameter(const std::shared_ptr<const AbsParameter> & parameter, const AbsFunction *function);
   
     // Copy constructor
     FunctionTimesParameter(const FunctionTimesParameter &right);
@@ -67,7 +67,7 @@ namespace Genfun {
     const FunctionTimesParameter & operator=(const FunctionTimesParameter &right);
 
     const AbsFunction  *_function;
-    AbsParameter       *_parameter;
+    std::shared_ptr<const AbsParameter> _parameter;
 
   };
 } // namespace Genfun

--- a/QatGenericFunctions/QatGenericFunctions/FunctionTimesParameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/FunctionTimesParameter.h
@@ -40,7 +40,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    FunctionTimesParameter(const std::shared_ptr<const AbsParameter> & parameter, const AbsFunction *function);
+    FunctionTimesParameter(const std::shared_ptr<const AbsParameter> & parameter, const std::shared_ptr<const AbsFunction>  & function);
   
     // Copy constructor
     FunctionTimesParameter(const FunctionTimesParameter &right);
@@ -66,7 +66,7 @@ namespace Genfun {
     // It is illegal to assign a FunctionTimesParameter
     const FunctionTimesParameter & operator=(const FunctionTimesParameter &right);
 
-    const AbsFunction  *_function;
+    std::shared_ptr<const AbsFunction > _function;
     std::shared_ptr<const AbsParameter> _parameter;
 
   };

--- a/QatGenericFunctions/QatGenericFunctions/HermitePolynomial.h
+++ b/QatGenericFunctions/QatGenericFunctions/HermitePolynomial.h
@@ -31,7 +31,6 @@
 #ifndef HermitePolynomial_h_
 #define HermitePolynomial_h_ 1
 #include "QatGenericFunctions/AbsFunction.h"
-#include "QatGenericFunctions/Parameter.h"
 #include "QatGenericFunctions/Defs.h"
 
 namespace Genfun {

--- a/QatGenericFunctions/QatGenericFunctions/IncompleteGamma.h
+++ b/QatGenericFunctions/QatGenericFunctions/IncompleteGamma.h
@@ -72,7 +72,7 @@ namespace Genfun {
     Type _type;
 
     // Here is the parameter of the Incomplete Gamma Function
-    Parameter _a;
+    std::shared_ptr<Parameter> _a;
   };
 } // namespace Genfun
 #include "QatGenericFunctions/IncompleteGamma.icc"

--- a/QatGenericFunctions/QatGenericFunctions/IncompleteGamma.icc
+++ b/QatGenericFunctions/QatGenericFunctions/IncompleteGamma.icc
@@ -104,26 +104,31 @@ Derivative IncompleteGamma::partial(unsigned int index) const {
   if (_type==UPPER) {
     Variable X;
     const AbsFunction & fPrime = -Power(_a.getValue()-1)(X) * Exp()(-X);
-    return Derivative(& fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
   else if (_type==LOWER) {
     Variable X;
     const AbsFunction & fPrime =  Power(_a.getValue()-1)(X) * Exp()(-X);
-    return Derivative(& fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
   else if (_type==Q) {
     Variable X;
     const AbsFunction & fPrime = -Power(_a.getValue()-1)(X) * Exp()(-X)/tgamma(_a.getValue());
-    return Derivative(& fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
   else if (_type==P) {
     Variable X;
     const AbsFunction & fPrime =  Power(_a.getValue()-1)(X) * Exp()(-X)/tgamma(_a.getValue());
-    return Derivative(& fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
   else {
     const AbsFunction & fPrime =  FixedConstant(0.0);
-    return Derivative(&fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   } 
 }
 

--- a/QatGenericFunctions/QatGenericFunctions/IncompleteGamma.icc
+++ b/QatGenericFunctions/QatGenericFunctions/IncompleteGamma.icc
@@ -39,7 +39,7 @@ inline
 IncompleteGamma::IncompleteGamma(Type type):
   AbsFunction(),
   _type(type),
-  _a("a-parameter", 5 ,0, HUGE_VAL) 
+  _a(new Parameter("a-parameter", 5 ,0, HUGE_VAL)) 
 {
 }
 
@@ -57,13 +57,13 @@ _a(right._a)
 
 inline
 Parameter & IncompleteGamma::a() {
-  return _a;
+  return *_a;
 }
 
 
 inline
 const Parameter & IncompleteGamma::a() const {
-  return _a;
+  return *_a;
 }
 
 
@@ -75,16 +75,16 @@ double IncompleteGamma::operator() (double x) const {
   gsl_sf_result result;
   int status = -1;
   if (_type==P) {
-    status=gsl_sf_gamma_inc_P_e (_a.getValue(), x, &result);
+    status=gsl_sf_gamma_inc_P_e (a().getValue(), x, &result);
   }
   else if (_type==Q) {
-    status=gsl_sf_gamma_inc_Q_e (_a.getValue(), x, &result);
+    status=gsl_sf_gamma_inc_Q_e (a().getValue(), x, &result);
   }
   else if (_type==UPPER) {
-    status=gsl_sf_gamma_inc_e    (_a.getValue(), x, &result);
+    status=gsl_sf_gamma_inc_e    (a().getValue(), x, &result);
   }
   else if (_type==LOWER) {
-    status=tgamma(x)-gsl_sf_gamma_inc_e    (_a.getValue(), x, &result);
+    status=tgamma(x)-gsl_sf_gamma_inc_e    (a().getValue(), x, &result);
   }
   else {
     throw std::logic_error("Impossible condition in IncompleteGamma");
@@ -103,25 +103,25 @@ Derivative IncompleteGamma::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("IncompleteGamma: partial derivative index out of range");
   if (_type==UPPER) {
     Variable X;
-    const AbsFunction & fPrime = -Power(_a.getValue()-1)(X) * Exp()(-X);
+    const AbsFunction & fPrime = -Power(a().getValue()-1.0)(X) * Exp()(-X);
     std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
     return Derivative(deriv);
   }
   else if (_type==LOWER) {
     Variable X;
-    const AbsFunction & fPrime =  Power(_a.getValue()-1)(X) * Exp()(-X);
+    const AbsFunction & fPrime =  Power(a().getValue()-1.0)(X) * Exp()(-X);
     std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
     return Derivative(deriv);
   }
   else if (_type==Q) {
     Variable X;
-    const AbsFunction & fPrime = -Power(_a.getValue()-1)(X) * Exp()(-X)/tgamma(_a.getValue());
+    const AbsFunction & fPrime = -Power(a().getValue()-1.0)(X) * Exp()(-X)/tgamma(a().getValue());
     std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
     return Derivative(deriv);
   }
   else if (_type==P) {
     Variable X;
-    const AbsFunction & fPrime =  Power(_a.getValue()-1)(X) * Exp()(-X)/tgamma(_a.getValue());
+    const AbsFunction & fPrime =  Power(a().getValue()-1.0)(X) * Exp()(-X)/tgamma(a().getValue());
     std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
     return Derivative(deriv);
   }

--- a/QatGenericFunctions/QatGenericFunctions/InterpolatingFunction.h
+++ b/QatGenericFunctions/QatGenericFunctions/InterpolatingFunction.h
@@ -37,7 +37,6 @@
 #ifndef _InterpolatingFunction_h_
 #define _InterpolatingFunction_h_ 
 #include "QatGenericFunctions/AbsFunction.h"
-#include "QatGenericFunctions/Parameter.h"
 #include <vector>
 namespace Genfun {
 

--- a/QatGenericFunctions/QatGenericFunctions/InterpolatingPolynomial.h
+++ b/QatGenericFunctions/QatGenericFunctions/InterpolatingPolynomial.h
@@ -30,7 +30,6 @@
 #ifndef _InterpolatingPolynomial_h_
 #define _InterpolatingPolynomial_h_ 
 #include "QatGenericFunctions/AbsFunction.h"
-#include "QatGenericFunctions/Parameter.h"
 #include <vector>
 namespace Genfun {
 

--- a/QatGenericFunctions/QatGenericFunctions/LegendrePolynomial.h
+++ b/QatGenericFunctions/QatGenericFunctions/LegendrePolynomial.h
@@ -29,7 +29,6 @@
 #ifndef LegendrePolynomial_h
 #define LegendrePolynomial_h 1
 #include "QatGenericFunctions/AbsFunction.h"
-#include "QatGenericFunctions/Parameter.h"
 #include "QatGenericFunctions/Defs.h"
 namespace Genfun {
 

--- a/QatGenericFunctions/QatGenericFunctions/LegendrePolynomial.icc
+++ b/QatGenericFunctions/QatGenericFunctions/LegendrePolynomial.icc
@@ -93,11 +93,15 @@ Derivative LegendrePolynomial::partial(unsigned int index) const {
       (1/(X*X-1))*(X*LegendrePolynomial(_l,STD) - LegendrePolynomial(_l-1,STD)) * (_l*sqrt((2.0*_l+1)/2.0))
       :
       (1/(X*X-1))*(X*LegendrePolynomial(_l,STD) - LegendrePolynomial(_l-1,STD)) * (_l                     );
-    return Derivative(& fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
   else {
     const AbsFunction & fPrime   = FixedConstant(0.0);
-    return Derivative(& fPrime);
+    
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
+  
   }
 }
 

--- a/QatGenericFunctions/QatGenericFunctions/NormalDistribution.h
+++ b/QatGenericFunctions/QatGenericFunctions/NormalDistribution.h
@@ -72,10 +72,10 @@ namespace Genfun {
     const NormalDistribution & operator=(const NormalDistribution &right);
 
     // Here is the decay constant
-    Parameter _mean;
+    std::shared_ptr<Parameter> _mean;
 
     // Here is the sigma
-    Parameter _sigma;
+    std::shared_ptr<Parameter> _sigma;
   };
 } // namespace Genfun
 

--- a/QatGenericFunctions/QatGenericFunctions/Parameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/Parameter.h
@@ -100,7 +100,7 @@ namespace Genfun {
     double                _value;                // value
     double                _lowerLimit;           // lower limit
     double                _upperLimit;           // upper limit
-    const AbsParameter   *_sourceParameter;      // connection
+    std::shared_ptr<const AbsParameter   *> _sourceParameter;      // connection
   
   };
 std::ostream & operator << ( std::ostream & o, const Parameter &p);

--- a/QatGenericFunctions/QatGenericFunctions/Parameter.h
+++ b/QatGenericFunctions/QatGenericFunctions/Parameter.h
@@ -100,8 +100,9 @@ namespace Genfun {
     double                _value;                // value
     double                _lowerLimit;           // lower limit
     double                _upperLimit;           // upper limit
+    const Parameter       *_origin{nullptr};
     std::shared_ptr<const AbsParameter   *> _sourceParameter;      // connection
-  
+    
   };
 std::ostream & operator << ( std::ostream & o, const Parameter &p);
 } // namespace Genfun

--- a/QatGenericFunctions/QatGenericFunctions/ParameterComposition.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterComposition.h
@@ -40,7 +40,7 @@ namespace Genfun {
       public:
 
     // Constructor
-    ParameterComposition(const AbsFunction *arg1, const AbsParameter *arg2);
+    ParameterComposition(const std::shared_ptr<const AbsFunction> & arg1, const std::shared_ptr<const AbsParameter> & arg2);
 
     // Copy constructor
     ParameterComposition(const ParameterComposition &right);
@@ -57,8 +57,8 @@ namespace Genfun {
     // It is illegal to assign a ParameterComposition
     const ParameterComposition & operator=(const ParameterComposition &right);
 
-    const AbsFunction  *_arg1;
-    AbsParameter *_arg2;  
+    std::shared_ptr<const AbsFunction>  _arg1;
+    std::shared_ptr<const AbsParameter> _arg2;  
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ParameterDifference.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterDifference.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ParameterDifference(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2);
+    ParameterDifference(const std::shared_ptr<const AbsParameter> & arg1, const std::shared_ptr<const AbsParameter> & arg2);
   
     // Copy constructor
     ParameterDifference(const ParameterDifference &right);

--- a/QatGenericFunctions/QatGenericFunctions/ParameterDifference.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterDifference.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ParameterDifference(const AbsParameter *arg1, const AbsParameter *arg2);
+    ParameterDifference(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2);
   
     // Copy constructor
     ParameterDifference(const ParameterDifference &right);
@@ -55,8 +55,8 @@ namespace Genfun {
     // It is illegal to assign a ParameterDifference
     const ParameterDifference & operator=(const ParameterDifference &right);
 
-    AbsParameter *_arg1;
-    AbsParameter *_arg2;
+    std::shared_ptr<const AbsParameter> _arg1;
+    std::shared_ptr<const AbsParameter>_arg2;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ParameterNegation.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterNegation.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ParameterNegation(const AbsParameter *arg1);
+    ParameterNegation(std::shared_ptr<const AbsParameter> arg1);
   
     // Copy constructor
     ParameterNegation(const ParameterNegation &right);
@@ -56,7 +56,7 @@ namespace Genfun {
     const ParameterNegation & operator=(const ParameterNegation &right);
 
     // The parameter to be negated:
-    AbsParameter *_arg1;
+    std::shared_ptr<const AbsParameter> _arg1;
 
   };
 } // namespace Genfun

--- a/QatGenericFunctions/QatGenericFunctions/ParameterNegation.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterNegation.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ParameterNegation(std::shared_ptr<const AbsParameter> arg1);
+    ParameterNegation(const std::shared_ptr<const AbsParameter> & arg1);
   
     // Copy constructor
     ParameterNegation(const ParameterNegation &right);

--- a/QatGenericFunctions/QatGenericFunctions/ParameterProduct.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterProduct.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ParameterProduct(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2);
+    ParameterProduct(const std::shared_ptr<const AbsParameter> & arg1, const std::shared_ptr<const AbsParameter> & arg2);
   
     // Copy constructor
     ParameterProduct(const ParameterProduct &right);

--- a/QatGenericFunctions/QatGenericFunctions/ParameterProduct.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterProduct.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ParameterProduct(const AbsParameter *arg1, const AbsParameter *arg2);
+    ParameterProduct(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2);
   
     // Copy constructor
     ParameterProduct(const ParameterProduct &right);
@@ -55,8 +55,8 @@ namespace Genfun {
     // It is illegal to assign a ParameterProduct
     const ParameterProduct & operator=(const ParameterProduct &right);
 
-    AbsParameter *_arg1;
-    AbsParameter *_arg2;
+    std::shared_ptr<const AbsParameter> _arg1;
+    std::shared_ptr<const AbsParameter> _arg2;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ParameterQuotient.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterQuotient.h
@@ -38,7 +38,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ParameterQuotient(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2);
+    ParameterQuotient(const std::shared_ptr<const AbsParameter> & arg1, const std::shared_ptr<const AbsParameter> & arg2);
   
     // Copy constructor
     ParameterQuotient(const ParameterQuotient &right);

--- a/QatGenericFunctions/QatGenericFunctions/ParameterQuotient.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterQuotient.h
@@ -38,7 +38,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ParameterQuotient(const AbsParameter *arg1, const AbsParameter *arg2);
+    ParameterQuotient(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2);
   
     // Copy constructor
     ParameterQuotient(const ParameterQuotient &right);
@@ -54,8 +54,8 @@ namespace Genfun {
     // It is illegal to assign a ParameterQuotient
     const ParameterQuotient & operator=(const ParameterQuotient &right);
 
-    AbsParameter *_arg1;
-    AbsParameter *_arg2;
+    std::shared_ptr<const AbsParameter> _arg1;
+    std::shared_ptr<const AbsParameter> _arg2;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ParameterSum.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterSum.h
@@ -28,6 +28,7 @@
 #ifndef ParameterSum_h
 #define ParameterSum_h 1
 #include "QatGenericFunctions/AbsParameter.h"
+#include <memory>
 
 namespace Genfun {
 
@@ -38,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ParameterSum(const AbsParameter *arg1, const AbsParameter *arg2);
+    ParameterSum(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2);
   
     // Copy constructor
     ParameterSum(const ParameterSum &right);
@@ -54,8 +55,8 @@ namespace Genfun {
     // It is illegal to assign a ParameterSum
     const ParameterSum & operator=(const ParameterSum &right);
 
-    AbsParameter *_arg1;
-    AbsParameter *_arg2;
+    std::shared_ptr<const AbsParameter>_arg1;
+    std::shared_ptr<const AbsParameter>_arg2;
   };
 } // namespace Genfun
 #endif

--- a/QatGenericFunctions/QatGenericFunctions/ParameterSum.h
+++ b/QatGenericFunctions/QatGenericFunctions/ParameterSum.h
@@ -39,7 +39,7 @@ namespace Genfun {
       public:
   
     // Constructor
-    ParameterSum(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2);
+    ParameterSum(const std::shared_ptr<const AbsParameter> & arg1, const std::shared_ptr<const AbsParameter> & arg2);
   
     // Copy constructor
     ParameterSum(const ParameterSum &right);

--- a/QatGenericFunctions/QatGenericFunctions/Polynomial.icc
+++ b/QatGenericFunctions/QatGenericFunctions/Polynomial.icc
@@ -70,7 +70,9 @@ namespace Genfun {
     if (index!=0) throw std::range_error("Polynomial: partial derivative index out of range");
     std::vector<double> d=coefficientsOfDerivative();
     Polynomial fPrime(d.begin(),d.end());
-    return Derivative(&fPrime);
+
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
   
   // Get the roots of this polynomial:

--- a/QatGenericFunctions/QatGenericFunctions/VoigtDistribution.h
+++ b/QatGenericFunctions/QatGenericFunctions/VoigtDistribution.h
@@ -65,8 +65,8 @@ namespace Genfun {
     
     // Here are the two parameters delta and sigma:
 
-    Parameter       _delta;
-    Parameter       _sigma;
+    std::shared_ptr<Parameter>       _delta;
+    std::shared_ptr<Parameter>       _sigma;
 
 
   };

--- a/QatGenericFunctions/src/ACos.cpp
+++ b/QatGenericFunctions/src/ACos.cpp
@@ -51,7 +51,8 @@ Derivative ACos::partial(unsigned int index) const {
   Sqrt   root;
 
   const AbsFunction & fPrime = - 1.0/root(1.0-square) ;
-  return Derivative(& fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
 }
 
 } // end namespace Genfun 

--- a/QatGenericFunctions/src/ACosh.cpp
+++ b/QatGenericFunctions/src/ACosh.cpp
@@ -51,7 +51,8 @@ Derivative ACosh::partial(unsigned int index) const {
   Sqrt   root;
 
   const AbsFunction & fPrime =  1.0/root(square-1) ;
-  return Derivative(& fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
 }
 
 } // end namespace Genfun 

--- a/QatGenericFunctions/src/ASin.cpp
+++ b/QatGenericFunctions/src/ASin.cpp
@@ -52,7 +52,8 @@ Derivative ASin::partial(unsigned int index) const {
   Sqrt   root;
 
   const AbsFunction & fPrime =  1.0/root(1.0-square) ;
-  return Derivative(& fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
 }
 
 } // end namespace Genfun 

--- a/QatGenericFunctions/src/ASinh.cpp
+++ b/QatGenericFunctions/src/ASinh.cpp
@@ -52,7 +52,9 @@ Derivative ASinh::partial(unsigned int index) const {
   Sqrt   root;
 
   const AbsFunction & fPrime =  1.0/root(1.0+square) ;
-  return Derivative(& fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+  
 }
 
 } // end namespace Genfun 

--- a/QatGenericFunctions/src/ATan.cpp
+++ b/QatGenericFunctions/src/ATan.cpp
@@ -50,7 +50,9 @@ Derivative ATan::partial(unsigned int index) const {
   Square square;
   
   const AbsFunction & fPrime=1.0/(1.0+square);;
-  return Derivative(& fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 } // end namespace Genfun 

--- a/QatGenericFunctions/src/ATanh.cpp
+++ b/QatGenericFunctions/src/ATanh.cpp
@@ -49,8 +49,11 @@ Derivative ATanh::partial(unsigned int index) const {
 
   Square square;
   
-  const AbsFunction & fPrime=1.0/(1.0-square);;
-  return Derivative(& fPrime);
+  const AbsFunction & fPrime=1.0/(1.0-square);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 } // end namespace Genfun 

--- a/QatGenericFunctions/src/AbsFunction.cpp
+++ b/QatGenericFunctions/src/AbsFunction.cpp
@@ -48,16 +48,22 @@ AbsFunction::AbsFunction(const AbsFunction &) {
 }
 
 FunctionComposition AbsFunction::operator () (const AbsFunction &function) const {
-  return FunctionComposition(this, &function);
+  const std::shared_ptr<const AbsFunction> o1{this->clone()};
+  const std::shared_ptr<const AbsFunction> o2{function.clone()};
+  return FunctionComposition(o1, o2);
 }
 
 ParameterComposition AbsFunction::operator() (const AbsParameter &p) const {
-  return ParameterComposition(this, &p);
+  const std::shared_ptr<const AbsFunction> o1{this->clone()};
+  const std::shared_ptr<const AbsParameter> o2{p.clone()};
+  return ParameterComposition(o1, o2);
 }
 
 Derivative AbsFunction::partial(unsigned int index) const {
-  FunctionNumDeriv fPrime(this,index);
-  return Derivative(&fPrime);
+  std::shared_ptr<const AbsFunction> o{this->clone()};
+  FunctionNumDeriv fPrime(o,index);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
 }
 
 
@@ -71,24 +77,29 @@ Derivative AbsFunction::prime() const {
 }
 
 FunctionSum operator + (const AbsFunction & a, const AbsFunction & b) {
-  return FunctionSum(&a,&b);
+  const std::shared_ptr<const AbsFunction> o1{a.clone()},o2{b.clone()};
+  return FunctionSum(o1,o2);
 }
 
 FunctionDifference operator - (const AbsFunction & a, const AbsFunction & b) {
-  return FunctionDifference(&a,&b);
+  const std::shared_ptr<const AbsFunction> o1{a.clone()},o2{b.clone()};
+  return FunctionDifference(o1,o2);
 }
 
 FunctionProduct operator * (const AbsFunction & a, const AbsFunction & b) {
-  return FunctionProduct(&a,&b);
+  const std::shared_ptr<const AbsFunction> o1{a.clone()},o2{b.clone()};
+  return FunctionProduct(o1,o2);
 }
 
 FunctionQuotient operator / (const AbsFunction & a, const AbsFunction & b) {
-  return FunctionQuotient(&a,&b);
+  const std::shared_ptr<const AbsFunction> o1{a.clone()},o2{b.clone()};
+  return FunctionQuotient(o1,o2);
 }
 
 
 FunctionNegation operator - (const AbsFunction & a) {
-  return FunctionNegation(&a);
+  std::shared_ptr<const AbsFunction> o{a.clone()};
+  return FunctionNegation(o);
 }
 
 unsigned int AbsFunction::dimensionality() const {
@@ -149,17 +160,18 @@ FunctionTimesParameter operator * (const AbsFunction &f, const AbsParameter & p)
 
 FunctionPlusParameter operator + (const AbsFunction &f, const AbsParameter & p) {
   std::shared_ptr<const AbsParameter> o{p.clone()}; 
-  return FunctionPlusParameter(o, &f);
+  std::shared_ptr<const AbsFunction>  of{f.clone()};
+  return FunctionPlusParameter(o, of);
 }
 
 FunctionPlusParameter operator - (const AbsFunction &f, const AbsParameter & p) {
   std::shared_ptr<const AbsParameter> o{(-p).clone()}; 
-  return FunctionPlusParameter(o, &f);
+  std::shared_ptr<const AbsFunction>  of{f.clone()};
+  return FunctionPlusParameter(o, of);
   
 }
 
 FunctionTimesParameter operator / (const AbsFunction &f, const AbsParameter & p) {
-  //  GENPARAMETER oneOverP = 1.0/p;
   std::shared_ptr<const AbsParameter> op{(1.0/p).clone()};
   std::shared_ptr<const AbsFunction>  of{f.clone()};
   return FunctionTimesParameter(op, of);
@@ -173,13 +185,15 @@ FunctionTimesParameter operator * (const AbsParameter & p, const AbsFunction &f)
 
 FunctionPlusParameter operator + (const AbsParameter & p, const AbsFunction &f) {
   std::shared_ptr<const AbsParameter> o{p.clone()};
-  return FunctionPlusParameter(o, &f);
+  std::shared_ptr<const AbsFunction>  of{f.clone()};
+  return FunctionPlusParameter(o, of);
 }
 
 FunctionPlusParameter operator - (const AbsParameter & p, const AbsFunction &f) {
   GENFUNCTION MinusF = -f;
   std::shared_ptr<const AbsParameter> o{p.clone()};
-  return FunctionPlusParameter(o, &MinusF);
+  std::shared_ptr<const AbsFunction>  of{MinusF.clone()};
+  return FunctionPlusParameter(o, of);
 }
 
 FunctionTimesParameter operator / (const AbsParameter & p, const AbsFunction &f) {

--- a/QatGenericFunctions/src/AbsFunction.cpp
+++ b/QatGenericFunctions/src/AbsFunction.cpp
@@ -134,39 +134,46 @@ ConstOverFunction          operator / (double c, const AbsFunction &op2) {
 
 
 FunctionTimesParameter operator * (const AbsFunction &f, const AbsParameter & p) {
-  return FunctionTimesParameter(&p, &f);
+  std::shared_ptr<const AbsParameter> o{p.clone()};
+  return FunctionTimesParameter(o, &f);
 }
 
 FunctionPlusParameter operator + (const AbsFunction &f, const AbsParameter & p) {
-  return FunctionPlusParameter(&p, &f);
+  std::shared_ptr<const AbsParameter> o{p.clone()}; 
+  return FunctionPlusParameter(o, &f);
 }
 
 FunctionPlusParameter operator - (const AbsFunction &f, const AbsParameter & p) {
-  GENPARAMETER MinusP = -p;
-  return FunctionPlusParameter(&MinusP, &f);
+  std::shared_ptr<const AbsParameter> o{(-p).clone()}; 
+  return FunctionPlusParameter(o, &f);
   
 }
 
 FunctionTimesParameter operator / (const AbsFunction &f, const AbsParameter & p) {
-  GENPARAMETER oneOverP = 1.0/p;
-  return FunctionTimesParameter(&oneOverP, &f);
+  //  GENPARAMETER oneOverP = 1.0/p;
+  std::shared_ptr<const AbsParameter> o{(1.0/p).clone()};
+  return FunctionTimesParameter(o, &f);
 }
 
 FunctionTimesParameter operator * (const AbsParameter & p, const AbsFunction &f) {
-  return FunctionTimesParameter(&p, &f);
+  std::shared_ptr<const AbsParameter> o{p.clone()};
+  return FunctionTimesParameter(o, &f);
 }
 
 FunctionPlusParameter operator + (const AbsParameter & p, const AbsFunction &f) {
-  return FunctionPlusParameter(&p, &f);
+  std::shared_ptr<const AbsParameter> o{p.clone()};
+  return FunctionPlusParameter(o, &f);
 }
 
 FunctionPlusParameter operator - (const AbsParameter & p, const AbsFunction &f) {
   GENFUNCTION MinusF = -f;
-  return FunctionPlusParameter(&p, &MinusF);
+  std::shared_ptr<const AbsParameter> o{p.clone()};
+  return FunctionPlusParameter(o, &MinusF);
 }
 
 FunctionTimesParameter operator / (const AbsParameter & p, const AbsFunction &f) {
   GENFUNCTION oneOverF = 1.0/f;
-  return FunctionTimesParameter(&p, &oneOverF);
+  std::shared_ptr<const AbsParameter> o{p.clone()};
+  return FunctionTimesParameter(o, &oneOverF);
 }
 } // namespace Genfun

--- a/QatGenericFunctions/src/AbsFunction.cpp
+++ b/QatGenericFunctions/src/AbsFunction.cpp
@@ -100,42 +100,51 @@ FunctionDirectProduct operator % (const AbsFunction & a, const AbsFunction & b) 
 }
 
 ConstTimesFunction operator * (const AbsFunction &op2, double c) {
-  return ConstTimesFunction(c, &op2);
+  std::shared_ptr<const AbsFunction> o{op2.clone()};
+  return ConstTimesFunction(c, o);
 }
 
 ConstPlusFunction  operator + (const AbsFunction &op2, double c) {
-  return ConstPlusFunction(c,&op2);
+  std::shared_ptr<const AbsFunction> o{op2.clone()};
+  return ConstPlusFunction(c,o);
 }
 
 ConstPlusFunction  operator - (const AbsFunction &op2, double c) {
-  return ConstPlusFunction(-c, &op2);
+  std::shared_ptr<const AbsFunction> o{op2.clone()};
+  return ConstPlusFunction(-c, o);
 }
 
 ConstTimesFunction operator / (const AbsFunction &op2, double c) {
-  return ConstTimesFunction(1/c,&op2);
+  std::shared_ptr<const AbsFunction> o{op2.clone()};
+  return ConstTimesFunction(1/c, o);
 }
 
 
 ConstTimesFunction           operator * (double c, const AbsFunction &op2) {
-  return ConstTimesFunction(c,&op2);
+  std::shared_ptr<const AbsFunction> o{op2.clone()};
+  return ConstTimesFunction(c,o);
 }
 
 ConstPlusFunction               operator + (double c, const AbsFunction &op2) {
-  return ConstPlusFunction(c,&op2);
+  std::shared_ptr<const AbsFunction> o{op2.clone()};
+  return ConstPlusFunction(c,o);
 }
 
 ConstMinusFunction        operator - (double c, const AbsFunction &op2) {
-  return ConstMinusFunction(c,&op2);
+  std::shared_ptr<const AbsFunction> o{op2.clone()};
+  return ConstMinusFunction(c,o);
 }
 
 ConstOverFunction          operator / (double c, const AbsFunction &op2) {
-  return ConstOverFunction(c,&op2);
+  std::shared_ptr<const AbsFunction> o{op2.clone()};
+  return ConstOverFunction(c,o);
 }
 
 
 FunctionTimesParameter operator * (const AbsFunction &f, const AbsParameter & p) {
-  std::shared_ptr<const AbsParameter> o{p.clone()};
-  return FunctionTimesParameter(o, &f);
+  std::shared_ptr<const AbsParameter> op{p.clone()};
+  std::shared_ptr<const AbsFunction>  of{f.clone()};
+  return FunctionTimesParameter(op, of);
 }
 
 FunctionPlusParameter operator + (const AbsFunction &f, const AbsParameter & p) {
@@ -151,13 +160,15 @@ FunctionPlusParameter operator - (const AbsFunction &f, const AbsParameter & p) 
 
 FunctionTimesParameter operator / (const AbsFunction &f, const AbsParameter & p) {
   //  GENPARAMETER oneOverP = 1.0/p;
-  std::shared_ptr<const AbsParameter> o{(1.0/p).clone()};
-  return FunctionTimesParameter(o, &f);
+  std::shared_ptr<const AbsParameter> op{(1.0/p).clone()};
+  std::shared_ptr<const AbsFunction>  of{f.clone()};
+  return FunctionTimesParameter(op, of);
 }
 
 FunctionTimesParameter operator * (const AbsParameter & p, const AbsFunction &f) {
-  std::shared_ptr<const AbsParameter> o{p.clone()};
-  return FunctionTimesParameter(o, &f);
+  std::shared_ptr<const AbsParameter> op{p.clone()};
+  std::shared_ptr<const AbsFunction>  of{f.clone()};
+  return FunctionTimesParameter(op, of);
 }
 
 FunctionPlusParameter operator + (const AbsParameter & p, const AbsFunction &f) {
@@ -173,7 +184,8 @@ FunctionPlusParameter operator - (const AbsParameter & p, const AbsFunction &f) 
 
 FunctionTimesParameter operator / (const AbsParameter & p, const AbsFunction &f) {
   GENFUNCTION oneOverF = 1.0/f;
-  std::shared_ptr<const AbsParameter> o{p.clone()};
-  return FunctionTimesParameter(o, &oneOverF);
+  std::shared_ptr<const AbsParameter> op{p.clone()};
+  std::shared_ptr<const AbsFunction>  of{oneOverF.clone()};
+  return FunctionTimesParameter(op,of);
 }
 } // namespace Genfun

--- a/QatGenericFunctions/src/AbsParameter.cpp
+++ b/QatGenericFunctions/src/AbsParameter.cpp
@@ -40,24 +40,30 @@ AbsParameter *AbsParameter::clone() const {
 
   
 ParameterSum operator + (const AbsParameter & a, const AbsParameter & b) {
-  return ParameterSum(&a,&b);
+  std::shared_ptr<const AbsParameter> o1{a.clone()},o2{b.clone()};
+  return ParameterSum(o1,o2);
+
 }
 
 ParameterDifference operator - (const AbsParameter & a, const AbsParameter & b) {
-  return ParameterDifference(&a,&b);
+  std::shared_ptr<const AbsParameter> o1{a.clone()},o2{b.clone()};
+  return ParameterDifference(o1,o2);
 }
 
 ParameterProduct operator * (const AbsParameter & a, const AbsParameter & b) {
-  return ParameterProduct(&a,&b);
+  std::shared_ptr<const AbsParameter> o1{a.clone()},o2{b.clone()};
+  return ParameterProduct(o1,o2);
 }
 
 ParameterQuotient operator / (const AbsParameter & a, const AbsParameter & b) {
-  return ParameterQuotient(&a,&b);
+  std::shared_ptr<const AbsParameter> o1{a.clone()},o2{b.clone()};
+  return ParameterQuotient(o1,o2);
 }
 
 
 ParameterNegation operator - (const AbsParameter & a) {
-  return ParameterNegation(&a);
+  std::shared_ptr<const AbsParameter> o{a.clone()};
+  return ParameterNegation(o);
 }
 
 

--- a/QatGenericFunctions/src/AbsParameter.cpp
+++ b/QatGenericFunctions/src/AbsParameter.cpp
@@ -68,35 +68,43 @@ ParameterNegation operator - (const AbsParameter & a) {
 
 
 ConstTimesParameter           operator * (double c, const AbsParameter &op2){
-  return ConstTimesParameter (c, &op2);
+  std::shared_ptr<const AbsParameter> o{op2.clone()};
+  return ConstTimesParameter (c, o);
 }
 
 ConstPlusParameter               operator + (double c, const AbsParameter &op2){
-  return ConstPlusParameter (c, &op2);
+ std::shared_ptr<const AbsParameter> o{op2.clone()};
+ return ConstPlusParameter (c, o);
 }
 
 ConstMinusParameter        operator - (double c, const AbsParameter &op2){
-  return ConstMinusParameter(c, &op2);
+  std::shared_ptr<const AbsParameter> o{op2.clone()};
+  return ConstMinusParameter(c, o);
 }
 
 ConstOverParameter          operator / (double c, const AbsParameter &op2){
-  return ConstOverParameter(c, &op2);
+ std::shared_ptr<const AbsParameter> o{op2.clone()};
+ return ConstOverParameter(c, o);
 }
 
 ConstTimesParameter           operator * (const AbsParameter &op2, double c){
-  return ConstTimesParameter (c, &op2);
+ std::shared_ptr<const AbsParameter> o{op2.clone()};
+ return ConstTimesParameter (c, o);
 }
 
 ConstPlusParameter               operator + (const AbsParameter &op2, double c){
-  return ConstPlusParameter (c, &op2);
+ std::shared_ptr<const AbsParameter> o{op2.clone()};
+ return ConstPlusParameter (c, o);
 }
 
 ConstPlusParameter        operator - (const AbsParameter &op2, double c){
-  return ConstPlusParameter(-c, &op2);
+  std::shared_ptr<const AbsParameter> o{op2.clone()};
+  return ConstPlusParameter(-c, o);
 }
 
 ConstTimesParameter          operator / (const AbsParameter &op2, double c){
-  return ConstTimesParameter(1/c, &op2);
+  std::shared_ptr<const AbsParameter> o{op2.clone()};
+  return ConstTimesParameter(1/c, o);
 }
 
 

--- a/QatGenericFunctions/src/ArrayFunction.cpp
+++ b/QatGenericFunctions/src/ArrayFunction.cpp
@@ -53,7 +53,9 @@ double ArrayFunction::operator ()(double argument) const {
 Derivative ArrayFunction::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("ArrayFunction: partial derivative index out of range");
   FixedConstant fPrime(0.0);
-  return Derivative(&fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
 }
 
 }

--- a/QatGenericFunctions/src/BetaDistribution.cpp
+++ b/QatGenericFunctions/src/BetaDistribution.cpp
@@ -29,8 +29,8 @@ FUNCTION_OBJECT_IMP(BetaDistribution)
 
 
 BetaDistribution::BetaDistribution():
-_alpha("a", 1.0, 0.0, 100),
-  _beta ("beta", 1.0, 0.0, 100)
+_alpha(new Parameter("a", 1.0, 0.0, 100)),
+  _beta (new Parameter("beta", 1.0, 0.0, 100))
 {}
   
   BetaDistribution::BetaDistribution(const BetaDistribution & right):
@@ -44,19 +44,19 @@ _alpha("a", 1.0, 0.0, 100),
   }
   
   double BetaDistribution::operator() (double x) const {
-    double a = _alpha.getValue(),b=_beta.getValue();
+    double a = _alpha->getValue(),b=_beta->getValue();
     return pow(x,a-1)*pow((1-x),b-1)*
       exp(lgamma(a+b)-lgamma(a)-lgamma(b));
     
   }
   
   Parameter & BetaDistribution::alpha() {
-    return _alpha;
+    return *_alpha;
   }
   
   
   Parameter & BetaDistribution::beta() {
-    return _beta;
+    return *_beta;
   }
   
   

--- a/QatGenericFunctions/src/ConstMinusFunction.cpp
+++ b/QatGenericFunctions/src/ConstMinusFunction.cpp
@@ -26,16 +26,16 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(ConstMinusFunction)
 
-ConstMinusFunction::ConstMinusFunction(double constant, const AbsFunction *arg):
+ConstMinusFunction::ConstMinusFunction(double constant, const std::shared_ptr<const AbsFunction>   & arg):
   _constant(constant),
-  _arg(arg->clone())
+  _arg(arg)
 {
 }
 
 ConstMinusFunction::ConstMinusFunction(const ConstMinusFunction & right) :
 AbsFunction(right),
 _constant(right._constant),
-_arg(right._arg->clone())
+_arg(right._arg)
 {}
 
 unsigned int ConstMinusFunction::dimensionality() const {
@@ -44,7 +44,6 @@ unsigned int ConstMinusFunction::dimensionality() const {
 
 ConstMinusFunction::~ConstMinusFunction()
 {
-  delete _arg;
 }
 
 

--- a/QatGenericFunctions/src/ConstMinusFunction.cpp
+++ b/QatGenericFunctions/src/ConstMinusFunction.cpp
@@ -63,7 +63,9 @@ double ConstMinusFunction::operator ()(const Argument & x) const
 Derivative ConstMinusFunction::partial(unsigned int index) const {
   const Derivative & d=_arg->partial(index);
   const AbsFunction & fPrime = -d;
-  return Derivative(& fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
 }
 
 

--- a/QatGenericFunctions/src/ConstMinusParameter.cpp
+++ b/QatGenericFunctions/src/ConstMinusParameter.cpp
@@ -27,23 +27,21 @@ namespace Genfun {
 PARAMETER_OBJECT_IMP(ConstMinusParameter)
 
 
-ConstMinusParameter::ConstMinusParameter(double xconstant, const AbsParameter *aparm):
+ConstMinusParameter::ConstMinusParameter(double xconstant, const std::shared_ptr<const AbsParameter> & aparm):
   _constant(xconstant),
-  _parameter(aparm->clone())
+  _parameter(aparm)
 {
-  if (aparm->parameter() && _parameter->parameter()) _parameter->parameter()->connectFrom(aparm->parameter());
 }
 
 ConstMinusParameter::ConstMinusParameter(const ConstMinusParameter & right) :
 AbsParameter(right),
 _constant(right._constant),
-_parameter(right._parameter->clone())
+_parameter(right._parameter)
 {}
 
 
 ConstMinusParameter::~ConstMinusParameter()
 {
-  delete _parameter;
 }
 
 

--- a/QatGenericFunctions/src/ConstOverFunction.cpp
+++ b/QatGenericFunctions/src/ConstOverFunction.cpp
@@ -26,16 +26,16 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(ConstOverFunction)
 
-ConstOverFunction::ConstOverFunction(double constant, const AbsFunction *arg):
+ConstOverFunction::ConstOverFunction(double constant, const std::shared_ptr<const AbsFunction> &arg):
   _constant(constant),
-  _arg(arg->clone())
+  _arg(arg)
 {
 }
 
 ConstOverFunction::ConstOverFunction(const ConstOverFunction & right) :
 AbsFunction(right),
 _constant(right._constant),
-_arg(right._arg->clone())
+_arg(right._arg)
 {}
 
 unsigned int ConstOverFunction::dimensionality() const {
@@ -44,7 +44,6 @@ unsigned int ConstOverFunction::dimensionality() const {
 
 ConstOverFunction::~ConstOverFunction()
 {
-  delete _arg;
 }
 
 

--- a/QatGenericFunctions/src/ConstOverFunction.cpp
+++ b/QatGenericFunctions/src/ConstOverFunction.cpp
@@ -64,8 +64,11 @@ Derivative ConstOverFunction::partial(unsigned int index) const {
   // d/dx (k/f) = -(k/f^2)(df/dx)
   Derivative d=_arg->partial(index);
   const AbsFunction & fPrime = -_constant/(*_arg)/(*_arg)*(d);
-  return Derivative(& fPrime);
-}
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
+  }
 
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/ConstOverParameter.cpp
+++ b/QatGenericFunctions/src/ConstOverParameter.cpp
@@ -26,23 +26,21 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ConstOverParameter)
 
-ConstOverParameter::ConstOverParameter(double xconstant, const AbsParameter *aparm):
+ConstOverParameter::ConstOverParameter(double xconstant, const std::shared_ptr<const AbsParameter> & aparm):
   _constant(xconstant),
-  _parameter(aparm->clone())
+  _parameter(aparm)
 {
-  if (aparm->parameter() && _parameter->parameter()) _parameter->parameter()->connectFrom(aparm->parameter());
 }
 
 ConstOverParameter::ConstOverParameter(const ConstOverParameter & right) :
 AbsParameter(right),
 _constant(right._constant),
-_parameter(right._parameter->clone())
+_parameter(right._parameter)
 {}
 
 
 ConstOverParameter::~ConstOverParameter()
 {
-  delete _parameter;
 }
 
 

--- a/QatGenericFunctions/src/ConstPlusFunction.cpp
+++ b/QatGenericFunctions/src/ConstPlusFunction.cpp
@@ -25,16 +25,16 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(ConstPlusFunction)
 
-ConstPlusFunction::ConstPlusFunction(double constant, const AbsFunction *arg):
+ConstPlusFunction::ConstPlusFunction(double constant, const std::shared_ptr<const AbsFunction>  &arg):
   _constant(constant),
-  _arg(arg->clone())
+  _arg(arg)
 {
 }
 
 ConstPlusFunction::ConstPlusFunction(const ConstPlusFunction & right) :
 AbsFunction(right),
 _constant(right._constant),
-_arg(right._arg->clone())
+_arg(right._arg)
 {}
 
 unsigned int ConstPlusFunction::dimensionality() const {
@@ -43,7 +43,6 @@ unsigned int ConstPlusFunction::dimensionality() const {
 
 ConstPlusFunction::~ConstPlusFunction()
 {
-  delete _arg;
 }
 
 

--- a/QatGenericFunctions/src/ConstPlusParameter.cpp
+++ b/QatGenericFunctions/src/ConstPlusParameter.cpp
@@ -26,23 +26,21 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ConstPlusParameter)
 
-ConstPlusParameter::ConstPlusParameter(double xconstant, const AbsParameter *aparm):
+ConstPlusParameter::ConstPlusParameter(double xconstant, const std::shared_ptr<const AbsParameter> & aparm):
   _constant(xconstant),
-  _parameter(aparm->clone())
+  _parameter(aparm)
 {
-  if (aparm->parameter() && _parameter->parameter()) _parameter->parameter()->connectFrom(aparm->parameter());
 }
 
 ConstPlusParameter::ConstPlusParameter(const ConstPlusParameter & right) :
 AbsParameter(),
 _constant(right._constant),
-_parameter(right._parameter->clone())
+_parameter(right._parameter)
 {}
 
 
 ConstPlusParameter::~ConstPlusParameter()
 {
-  delete _parameter;
 }
 
 

--- a/QatGenericFunctions/src/ConstTimesFunction.cpp
+++ b/QatGenericFunctions/src/ConstTimesFunction.cpp
@@ -25,16 +25,16 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(ConstTimesFunction)
 
-ConstTimesFunction::ConstTimesFunction(double constant, const AbsFunction *arg):
+ConstTimesFunction::ConstTimesFunction(double constant, const std::shared_ptr<const AbsFunction> &arg):
   _constant(constant),
-  _arg(arg->clone())
+  _arg(arg)
 {
 }
 
 ConstTimesFunction::ConstTimesFunction(const ConstTimesFunction & right) :
 AbsFunction(right),
 _constant(right._constant),
-_arg(right._arg->clone())
+_arg(right._arg)
 {}
 
 unsigned int ConstTimesFunction::dimensionality() const {
@@ -43,7 +43,6 @@ unsigned int ConstTimesFunction::dimensionality() const {
 
 ConstTimesFunction::~ConstTimesFunction()
 {
-  delete _arg;
 }
 
 

--- a/QatGenericFunctions/src/ConstTimesFunction.cpp
+++ b/QatGenericFunctions/src/ConstTimesFunction.cpp
@@ -62,7 +62,10 @@ double ConstTimesFunction::operator ()(const Argument & x) const
     // d/dx (k*f) = k*(df/dx)
     const Derivative & d=_arg->partial(index);
     const AbsFunction & fPrime = _constant*d;
-    return Derivative(& fPrime);
+
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
+
   }
   
 } // namespace Genfun

--- a/QatGenericFunctions/src/ConstTimesParameter.cpp
+++ b/QatGenericFunctions/src/ConstTimesParameter.cpp
@@ -26,23 +26,21 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ConstTimesParameter)
 
-ConstTimesParameter::ConstTimesParameter(double xconstant, const AbsParameter *aparm):
+ConstTimesParameter::ConstTimesParameter(double xconstant, const std::shared_ptr<const AbsParameter> & aparm):
   _constant(xconstant),
-  _parameter(aparm->clone())
+  _parameter(aparm)
 {
-  if (aparm->parameter() && _parameter->parameter()) _parameter->parameter()->connectFrom(aparm->parameter());
 }
 
 ConstTimesParameter::ConstTimesParameter(const ConstTimesParameter & right) :
 AbsParameter(),
 _constant(right._constant),
-_parameter(right._parameter->clone())
+_parameter(right._parameter)
 {}
 
 
 ConstTimesParameter::~ConstTimesParameter()
 {
-  delete _parameter;
 }
 
 

--- a/QatGenericFunctions/src/Cos.cpp
+++ b/QatGenericFunctions/src/Cos.cpp
@@ -46,7 +46,11 @@ double Cos::operator() (double x) const {
 Derivative Cos::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Cos:  partial derivative index ot of range");
   const AbsFunction & fPrime = -Sin();
-  return Derivative(& fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
+
 }
 
 

--- a/QatGenericFunctions/src/Cosh.cpp
+++ b/QatGenericFunctions/src/Cosh.cpp
@@ -45,7 +45,11 @@ double Cosh::operator() (double x) const {
 Derivative Cosh::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Cosh:  partial derivative index ot of range");
   const AbsFunction & fPrime = Sinh();
-  return Derivative(& fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
+ 
 }
 
 

--- a/QatGenericFunctions/src/Erf.cpp
+++ b/QatGenericFunctions/src/Erf.cpp
@@ -50,7 +50,10 @@ double Erf::operator() (double x) const {
     Genfun::NormalDistribution gauss;
     gauss.sigma().setValue(1/sqrt(2));
     GENFUNCTION fPrime=2.0*gauss;
-    return Derivative(&fPrime);
+
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
+
   }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/Exp.cpp
+++ b/QatGenericFunctions/src/Exp.cpp
@@ -45,7 +45,9 @@ double Exp::operator() (double x) const {
 
 Derivative Exp::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Exp: partial derivative index out of range");
-  return Derivative(this);
+  std::shared_ptr<const AbsFunction> deriv{clone()};
+  return Derivative(deriv);
+
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/FixedConstant.cpp
+++ b/QatGenericFunctions/src/FixedConstant.cpp
@@ -47,7 +47,9 @@ double FixedConstant::operator ()(double) const
 Derivative FixedConstant::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("FixedConstant: partial derivative index out of range");
   FixedConstant fPrime(0.0);
-  return Derivative(&fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/FunctionComposition.cpp
+++ b/QatGenericFunctions/src/FunctionComposition.cpp
@@ -27,7 +27,7 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionComposition)
 
-FunctionComposition::FunctionComposition(const AbsFunction *arg1, const AbsFunction *arg2):_arg1(arg1->clone()),_arg2(arg2->clone())
+FunctionComposition::FunctionComposition(const std::shared_ptr<const AbsFunction> & arg1, const std::shared_ptr<const AbsFunction> & arg2):_arg1(arg1),_arg2(arg2)
 {
   if (arg1->dimensionality()!=1) {
     throw std::runtime_error("Dimension mismatch in function composition");
@@ -36,14 +36,12 @@ FunctionComposition::FunctionComposition(const AbsFunction *arg1, const AbsFunct
 
 FunctionComposition::FunctionComposition(const FunctionComposition & right):
 AbsFunction(right),
-_arg1(right._arg1->clone()),
-_arg2(right._arg2->clone())
+_arg1(right._arg1),
+_arg2(right._arg2)
 {}
 
 FunctionComposition::~FunctionComposition()
 {
-  delete _arg1;
-  delete _arg2;
 }
 
 unsigned int FunctionComposition::dimensionality() const {
@@ -75,7 +73,10 @@ Derivative FunctionComposition::partial(unsigned int index) const {
   const Derivative & d1=_arg1->partial(0);
   const Derivative & d2=_arg2->partial(index);
   const AbsFunction & fPrime = d1(*_arg2)*d2;
-  return Derivative(&fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
+  
 }
 
 

--- a/QatGenericFunctions/src/FunctionDifference.cpp
+++ b/QatGenericFunctions/src/FunctionDifference.cpp
@@ -27,9 +27,9 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionDifference)
 
-FunctionDifference::FunctionDifference(const AbsFunction *arg1, const AbsFunction *arg2):
-  _arg1(arg1->clone()),
-  _arg2(arg2->clone())
+FunctionDifference::FunctionDifference(const std::shared_ptr<const AbsFunction> &arg1, const std::shared_ptr<const AbsFunction> &arg2):
+  _arg1(arg1),
+  _arg2(arg2)
 {
   if (arg1->dimensionality()!=arg2->dimensionality()) {
     throw std::runtime_error("FunctionDifference: dimension mismatch");
@@ -39,8 +39,8 @@ FunctionDifference::FunctionDifference(const AbsFunction *arg1, const AbsFunctio
 
 FunctionDifference::FunctionDifference(const FunctionDifference & right):
   AbsFunction(right),
-  _arg1(right._arg1->clone()),
-  _arg2(right._arg2->clone())
+  _arg1(right._arg1),
+  _arg2(right._arg2)
 {
 }
 
@@ -51,8 +51,6 @@ unsigned int FunctionDifference::dimensionality() const {
 
 FunctionDifference::~FunctionDifference()
 {
-  delete _arg1;
-  delete _arg2;
 }
 
 
@@ -72,7 +70,10 @@ Derivative FunctionDifference::partial(unsigned int index) const {
   const Derivative & d1=_arg1->partial(index);
   const Derivative & d2=_arg2->partial(index);
   const AbsFunction & fPrime = d1-d2;
-  return Derivative(&fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 

--- a/QatGenericFunctions/src/FunctionDirectProduct.cpp
+++ b/QatGenericFunctions/src/FunctionDirectProduct.cpp
@@ -86,12 +86,16 @@ Derivative FunctionDirectProduct::partial(unsigned int index) const {
   if (index<_m) {
     const Derivative & d1=_arg1->partial(index);
     const AbsFunction & fPrime = d1%(*_arg2);
-    return Derivative(&fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
   else {
     const Derivative &d2=_arg2->partial(index-_m);
     const AbsFunction & fPrime = (*_arg1)%d2;
-    return Derivative(&fPrime);
+
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
+
   }
 }
 

--- a/QatGenericFunctions/src/FunctionNegation.cpp
+++ b/QatGenericFunctions/src/FunctionNegation.cpp
@@ -26,21 +26,21 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionNegation)
 
-FunctionNegation::FunctionNegation(const AbsFunction *arg1):
-  _arg1(arg1->clone())
+FunctionNegation::FunctionNegation(const std::shared_ptr<const AbsFunction> &arg1):
+  _arg1(arg1)
 {
 }
 
 FunctionNegation::FunctionNegation(const FunctionNegation & right):
   AbsFunction(right),
-  _arg1(right._arg1->clone())
+  _arg1(right._arg1)
 {
 }
 
 
 FunctionNegation::~FunctionNegation()
 {
-  delete _arg1;
+  
 }
 
 unsigned int FunctionNegation::dimensionality() const {
@@ -62,7 +62,10 @@ double FunctionNegation::operator ()(const Argument & x) const
 Derivative FunctionNegation::partial(unsigned int index) const {
   const Derivative & d = _arg1->partial(index);
   const AbsFunction & fPrime  = -d;
-  return Derivative(&fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
   

--- a/QatGenericFunctions/src/FunctionNoop.cpp
+++ b/QatGenericFunctions/src/FunctionNoop.cpp
@@ -26,20 +26,19 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionNoop)
 
-FunctionNoop::FunctionNoop(const AbsFunction *arg1):
-_arg1(arg1->clone())
+FunctionNoop::FunctionNoop(const std::shared_ptr<const AbsFunction> & arg1):
+_arg1(arg1)
 {
 }
 
 FunctionNoop::FunctionNoop(const FunctionNoop & right):
-  AbsFunction(right), _arg1(right._arg1->clone())
+  AbsFunction(right), _arg1(right._arg1)
 {
 }
 
 
 FunctionNoop::~FunctionNoop()
 {
-  delete _arg1;
 }
 
 unsigned int FunctionNoop::dimensionality() const {

--- a/QatGenericFunctions/src/FunctionNumDeriv.cpp
+++ b/QatGenericFunctions/src/FunctionNumDeriv.cpp
@@ -27,15 +27,15 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionNumDeriv)
 
-FunctionNumDeriv::FunctionNumDeriv(const AbsFunction *arg1, unsigned int index):
-  _arg1(arg1->clone()),
+FunctionNumDeriv::FunctionNumDeriv(const std::shared_ptr<const AbsFunction> & arg1, unsigned int index):
+  _arg1(arg1),
   _wrtIndex(index)
 {
 }
 
 FunctionNumDeriv::FunctionNumDeriv(const FunctionNumDeriv & right):
   AbsFunction(right),
-  _arg1(right._arg1->clone()),
+  _arg1(right._arg1),
   _wrtIndex(right._wrtIndex)
 {
 }
@@ -43,7 +43,6 @@ FunctionNumDeriv::FunctionNumDeriv(const FunctionNumDeriv & right):
 
 FunctionNumDeriv::~FunctionNumDeriv()
 {
-  delete _arg1;
 }
 
 unsigned int FunctionNumDeriv::dimensionality() const {

--- a/QatGenericFunctions/src/FunctionPlusParameter.cpp
+++ b/QatGenericFunctions/src/FunctionPlusParameter.cpp
@@ -26,19 +26,16 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionPlusParameter)
 
-FunctionPlusParameter::FunctionPlusParameter(const AbsParameter *parameter, const AbsFunction *function):
+FunctionPlusParameter::FunctionPlusParameter(const std::shared_ptr<const AbsParameter> & parameter, const AbsFunction *function):
   _function(function->clone()),
-  _parameter(parameter->clone())
+  _parameter(parameter)
 {
-  if (parameter->parameter() && _parameter->parameter()) {
-    _parameter->parameter()->connectFrom(parameter->parameter());
-  }
 }
 
 FunctionPlusParameter::FunctionPlusParameter(const FunctionPlusParameter & right) :
   AbsFunction(right),
   _function(right._function->clone()),
-  _parameter(right._parameter->clone())
+  _parameter(right._parameter)
 {}
 
 unsigned int FunctionPlusParameter::dimensionality() const {
@@ -48,7 +45,6 @@ unsigned int FunctionPlusParameter::dimensionality() const {
 FunctionPlusParameter::~FunctionPlusParameter()
 {
   delete _function;
-  delete _parameter;
 }
 
 

--- a/QatGenericFunctions/src/FunctionPlusParameter.cpp
+++ b/QatGenericFunctions/src/FunctionPlusParameter.cpp
@@ -26,15 +26,15 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionPlusParameter)
 
-FunctionPlusParameter::FunctionPlusParameter(const std::shared_ptr<const AbsParameter> & parameter, const AbsFunction *function):
-  _function(function->clone()),
+FunctionPlusParameter::FunctionPlusParameter(const std::shared_ptr<const AbsParameter> & parameter, const std::shared_ptr<const AbsFunction> & function):
+  _function(function),
   _parameter(parameter)
 {
 }
 
 FunctionPlusParameter::FunctionPlusParameter(const FunctionPlusParameter & right) :
   AbsFunction(right),
-  _function(right._function->clone()),
+  _function(right._function),
   _parameter(right._parameter)
 {}
 
@@ -44,7 +44,6 @@ unsigned int FunctionPlusParameter::dimensionality() const {
 
 FunctionPlusParameter::~FunctionPlusParameter()
 {
-  delete _function;
 }
 
 

--- a/QatGenericFunctions/src/FunctionProduct.cpp
+++ b/QatGenericFunctions/src/FunctionProduct.cpp
@@ -27,9 +27,9 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionProduct)
 
-FunctionProduct::FunctionProduct(const AbsFunction *arg1, const AbsFunction *arg2):
-_arg1(arg1->clone()),
-_arg2(arg2->clone())
+FunctionProduct::FunctionProduct(const std::shared_ptr<const AbsFunction> & arg1, const std::shared_ptr<const AbsFunction> & arg2):
+_arg1(arg1),
+_arg2(arg2)
 {
   if (arg1->dimensionality()!=arg2->dimensionality()) {
     throw std::runtime_error ("FunctionProduct:  dimension mismatch");
@@ -38,15 +38,13 @@ _arg2(arg2->clone())
 
 FunctionProduct::FunctionProduct(const FunctionProduct & right) :
   AbsFunction(right),
-  _arg1(right._arg1->clone()),
-  _arg2(right._arg2->clone())
+  _arg1(right._arg1),
+  _arg2(right._arg2)
 {
 }
 
 FunctionProduct::~FunctionProduct()
 {
-  delete _arg1;
-  delete _arg2;
 }
 
 
@@ -68,7 +66,10 @@ Derivative FunctionProduct::partial(unsigned int index) const {
   const Derivative & d1=_arg1->partial(index);
   const Derivative & d2=_arg2->partial(index);
   const AbsFunction & fPrime =  (*_arg1)*d2 + d1*(*_arg2);
-  return Derivative(&fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+    
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/FunctionQuotient.cpp
+++ b/QatGenericFunctions/src/FunctionQuotient.cpp
@@ -27,9 +27,9 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionQuotient)
 
-FunctionQuotient::FunctionQuotient(const AbsFunction *arg1, const AbsFunction *arg2):
-  _arg1(arg1->clone()),
-  _arg2(arg2->clone())
+FunctionQuotient::FunctionQuotient(const std::shared_ptr<const AbsFunction> & arg1, const std::shared_ptr<const AbsFunction> & arg2):
+  _arg1(arg1),
+  _arg2(arg2)
 {
   if (arg1->dimensionality()!=arg2->dimensionality()) {
     throw std::runtime_error ("FunctionQuotient:  dimension mismatch");
@@ -38,13 +38,11 @@ FunctionQuotient::FunctionQuotient(const AbsFunction *arg1, const AbsFunction *a
 
 FunctionQuotient::FunctionQuotient( const FunctionQuotient & right) :
 AbsFunction(right),
-_arg1(right._arg1->clone()),
-_arg2(right._arg2->clone())
+_arg1(right._arg1),
+_arg2(right._arg2)
 {}
 FunctionQuotient::~FunctionQuotient()
 {
-  delete _arg1;
-  delete _arg2;
 }
 
 unsigned int FunctionQuotient::dimensionality() const {
@@ -70,7 +68,12 @@ Derivative FunctionQuotient::partial(unsigned int index) const {
   const AbsFunction & fPrime  = 
     ((d1)*(*_arg2)-(*_arg1)*d2) / 
     (*_arg2)/ (*_arg2);
-  return Derivative(&fPrime);
+
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
+
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/FunctionSum.cpp
+++ b/QatGenericFunctions/src/FunctionSum.cpp
@@ -28,9 +28,9 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionSum)
 
-FunctionSum::FunctionSum(const AbsFunction *arg1, const AbsFunction *arg2):
-  _arg1(arg1->clone()),
-  _arg2(arg2->clone())
+FunctionSum::FunctionSum(const std::shared_ptr<const AbsFunction> & arg1, const std::shared_ptr<const AbsFunction> & arg2):
+  _arg1(arg1),
+  _arg2(arg2)
 {
   if (arg1->dimensionality()!=arg2->dimensionality()) {
     throw std::runtime_error ("FunctionSum:  dimension mismatch");
@@ -39,8 +39,8 @@ FunctionSum::FunctionSum(const AbsFunction *arg1, const AbsFunction *arg2):
 
 FunctionSum::FunctionSum(const FunctionSum & right) :
 AbsFunction(right),
-_arg1(right._arg1->clone()),
-_arg2(right._arg2->clone())
+_arg1(right._arg1),
+_arg2(right._arg2)
 {}
 
 unsigned int FunctionSum::dimensionality() const {
@@ -49,8 +49,6 @@ unsigned int FunctionSum::dimensionality() const {
 
 FunctionSum::~FunctionSum()
 {
-  delete _arg1;
-  delete _arg2;
 }
 
 
@@ -72,7 +70,11 @@ Derivative FunctionSum::partial(unsigned int index) const {
   const Derivative & d1=_arg1->partial(index);
   const Derivative & d2=_arg2->partial(index);
   const AbsFunction & fPrime  = d1+d2;
-  return Derivative(&fPrime);
+
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 

--- a/QatGenericFunctions/src/FunctionTimesParameter.cpp
+++ b/QatGenericFunctions/src/FunctionTimesParameter.cpp
@@ -26,19 +26,16 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionTimesParameter)
 
-FunctionTimesParameter::FunctionTimesParameter(const AbsParameter *parameter, const AbsFunction *function):
+FunctionTimesParameter::FunctionTimesParameter(const std::shared_ptr<const AbsParameter> &parameter, const AbsFunction *function):
   _function(function->clone()),
-  _parameter(parameter->clone())
+  _parameter(parameter)
 {
-  if (parameter->parameter() && _parameter->parameter()) {
-    _parameter->parameter()->connectFrom(parameter->parameter());
-  }
 }
 
 FunctionTimesParameter::FunctionTimesParameter(const FunctionTimesParameter & right) :
   AbsFunction(right),
   _function(right._function->clone()),
-  _parameter(right._parameter->clone())
+  _parameter(right._parameter)
 {}
 
 unsigned int FunctionTimesParameter::dimensionality() const {
@@ -48,7 +45,6 @@ unsigned int FunctionTimesParameter::dimensionality() const {
 FunctionTimesParameter::~FunctionTimesParameter()
 {
   delete _function;
-  delete _parameter;
 }
 
 

--- a/QatGenericFunctions/src/FunctionTimesParameter.cpp
+++ b/QatGenericFunctions/src/FunctionTimesParameter.cpp
@@ -26,15 +26,15 @@
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionTimesParameter)
 
-FunctionTimesParameter::FunctionTimesParameter(const std::shared_ptr<const AbsParameter> &parameter, const AbsFunction *function):
-  _function(function->clone()),
+FunctionTimesParameter::FunctionTimesParameter(const std::shared_ptr<const AbsParameter> &parameter, const std::shared_ptr<const AbsFunction> & function):
+  _function(function),
   _parameter(parameter)
 {
 }
 
 FunctionTimesParameter::FunctionTimesParameter(const FunctionTimesParameter & right) :
   AbsFunction(right),
-  _function(right._function->clone()),
+  _function(right._function),
   _parameter(right._parameter)
 {}
 
@@ -44,7 +44,6 @@ unsigned int FunctionTimesParameter::dimensionality() const {
 
 FunctionTimesParameter::~FunctionTimesParameter()
 {
-  delete _function;
 }
 
 

--- a/QatGenericFunctions/src/FunctionTimesParameter.cpp
+++ b/QatGenericFunctions/src/FunctionTimesParameter.cpp
@@ -64,7 +64,11 @@ double FunctionTimesParameter::operator ()(const Argument & x) const
 Derivative FunctionTimesParameter::partial(unsigned int index) const {
   const Derivative & d=_function->partial(index);
   const AbsFunction & fPrime  = (*_parameter)*d;
-  return Derivative(&fPrime);
+
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/HermitePolynomial.cpp
+++ b/QatGenericFunctions/src/HermitePolynomial.cpp
@@ -66,11 +66,13 @@ Derivative HermitePolynomial::partial(unsigned int index) const {
       2.0*_n*HermitePolynomial(_n-1,STD)/pow(M_PI, 0.25)/(pow(2.0,_n/2.0)*exp(lgamma(_n+1)/2.0))
       :
       2.0*_n*HermitePolynomial(_n-1,STD);
-    return Derivative(& fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
   else {
     const AbsFunction & fPrime   = FixedConstant(0.0);
-    return Derivative(& fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
 }
 

--- a/QatGenericFunctions/src/KVector.cpp
+++ b/QatGenericFunctions/src/KVector.cpp
@@ -59,7 +59,10 @@ double KVector::operator () (const Argument & a) const {
 Derivative KVector::partial(unsigned int ) const {
 
   KVector vec(_dimensionality,0.0);
-  return Derivative(&vec);
+
+  std::shared_ptr<const AbsFunction> deriv{vec.clone()};
+  return Derivative(deriv);
+
 }
 
 unsigned int KVector::dimensionality() const {

--- a/QatGenericFunctions/src/Log.cpp
+++ b/QatGenericFunctions/src/Log.cpp
@@ -47,7 +47,10 @@ double Log::operator() (double x) const {
 Derivative Log::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Log: partial derivative index out of range");
   GENFUNCTION fPrime=1/Variable();
-  return Derivative(&fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/NormalDistribution.cpp
+++ b/QatGenericFunctions/src/NormalDistribution.cpp
@@ -29,8 +29,8 @@ namespace Genfun {
 FUNCTION_OBJECT_IMP(NormalDistribution)
 
 NormalDistribution::NormalDistribution():
-  _mean("Mean", 0.0,-10,10),
-  _sigma("Sigma",1.0,0, 10)
+_mean(new Parameter("Mean", 0.0,-10,10)),
+  _sigma(new Parameter("Sigma",1.0,0, 10))
 {}
 
 NormalDistribution::~NormalDistribution() {
@@ -44,26 +44,26 @@ _sigma(right._sigma)
 }
 
 double NormalDistribution::operator() (double x) const {
-  double s   = _sigma.getValue();
-  double x0  = _mean.getValue();
+  double s   = _sigma->getValue();
+  double x0  = _mean->getValue();
   return (1.0/(sqrt(2*M_PI)*s))*
 	  exp(-(x-x0)*(x-x0)/(2.0*s*s));
 }
 
 Parameter & NormalDistribution::mean() {
-  return _mean;
+  return *_mean;
 }
 
 Parameter & NormalDistribution::sigma() {
-  return _sigma;
+  return *_sigma;
 }
 
 const Parameter & NormalDistribution::mean() const {
-  return _mean;
+  return *_mean;
 }
 
 const Parameter & NormalDistribution::sigma() const {
-  return _sigma;
+  return *_sigma;
 }
 
 
@@ -73,7 +73,7 @@ Derivative NormalDistribution::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("NormalDistribution: partial derivative index out of range");
 
   Variable x;
-  const AbsFunction & fPrime  = (*this)*(_mean-x)/_sigma/_sigma;
+  const AbsFunction & fPrime  = (*this)*(*_mean-x)/(*_sigma)/(*_sigma);
 
   std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
   return Derivative(deriv);

--- a/QatGenericFunctions/src/NormalDistribution.cpp
+++ b/QatGenericFunctions/src/NormalDistribution.cpp
@@ -74,7 +74,10 @@ Derivative NormalDistribution::partial(unsigned int index) const {
 
   Variable x;
   const AbsFunction & fPrime  = (*this)*(_mean-x)/_sigma/_sigma;
-  return Derivative(&fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/Parameter.cpp
+++ b/QatGenericFunctions/src/Parameter.cpp
@@ -46,6 +46,7 @@ const std::string & Parameter::getName() const {
 
 double Parameter::getValue() const
 {
+  if (_origin) return _origin->getValue();
   if (*_sourceParameter) {
     return (*_sourceParameter)->getValue();
   }
@@ -56,6 +57,7 @@ double Parameter::getValue() const
 
 double Parameter::getLowerLimit() const
 {
+  if (_origin) return _origin->getLowerLimit();
   if (*_sourceParameter) {
     return -1E-100;
   }
@@ -66,6 +68,7 @@ double Parameter::getLowerLimit() const
 
 double Parameter::getUpperLimit() const
 {
+  if (_origin) return _origin->getUpperLimit();
   if (*_sourceParameter) {
     return 1E100;
   }
@@ -88,6 +91,8 @@ void Parameter::setValue(double value)
 
 void Parameter::setLowerLimit(double lowerLimit)
 {
+
+
   if (*_sourceParameter) {
     std::cerr
       << "Warning:  Parameter is connected.  Function has no effect."
@@ -128,6 +133,7 @@ Parameter::Parameter(const Parameter & right):
   _value(right._value),
   _lowerLimit(right._lowerLimit),
   _upperLimit(right._upperLimit),
+  _origin(&right),
   _sourceParameter(right._sourceParameter)
 {
 }
@@ -138,6 +144,7 @@ const Parameter & Parameter::operator=(const Parameter &right) {
     _value=right._value;
     _lowerLimit=right._lowerLimit;
     _upperLimit=right._upperLimit;
+    _origin=&right;
     _sourceParameter=right._sourceParameter;
   }
   return *this;

--- a/QatGenericFunctions/src/Parameter.cpp
+++ b/QatGenericFunctions/src/Parameter.cpp
@@ -26,7 +26,7 @@ namespace Genfun {
 PARAMETER_OBJECT_IMP(Parameter)
 
 Parameter::Parameter(std::string name, double value, double lowerLimit, double upperLimit):
-  _name(name),_value(value),_lowerLimit(lowerLimit),_upperLimit(upperLimit),_sourceParameter(NULL)
+_name(name),_value(value),_lowerLimit(lowerLimit),_upperLimit(upperLimit),_sourceParameter(std::make_shared<const AbsParameter *>(nullptr))
 {
 } 
 
@@ -46,8 +46,8 @@ const std::string & Parameter::getName() const {
 
 double Parameter::getValue() const
 {
-  if (_sourceParameter) {
-    return _sourceParameter->getValue();
+  if (*_sourceParameter) {
+    return (*_sourceParameter)->getValue();
   }
   else {
     return _value;
@@ -56,7 +56,7 @@ double Parameter::getValue() const
 
 double Parameter::getLowerLimit() const
 {
-  if (_sourceParameter) {
+  if (*_sourceParameter) {
     return -1E-100;
   }
   else {
@@ -66,7 +66,7 @@ double Parameter::getLowerLimit() const
 
 double Parameter::getUpperLimit() const
 {
-  if (_sourceParameter) {
+  if (*_sourceParameter) {
     return 1E100;
   }
   else {
@@ -76,7 +76,7 @@ double Parameter::getUpperLimit() const
 
 void Parameter::setValue(double value)
 {
-  if (_sourceParameter) {
+  if (*_sourceParameter) {
     std::cerr
       << "Warning:  Parameter is connected.  Function has no effect."
       << std::endl;
@@ -88,7 +88,7 @@ void Parameter::setValue(double value)
 
 void Parameter::setLowerLimit(double lowerLimit)
 {
-  if (_sourceParameter) {
+  if (*_sourceParameter) {
     std::cerr
       << "Warning:  Parameter is connected.  Function has no effect."
       << std::endl;
@@ -100,7 +100,7 @@ void Parameter::setLowerLimit(double lowerLimit)
 
 void Parameter::setUpperLimit(double upperLimit)
 {
-  if (_sourceParameter) {
+  if (*_sourceParameter) {
     std::cerr
       << "Warning:  Parameter is connected.  Function has no effect."
       << std::endl;
@@ -113,11 +113,11 @@ void Parameter::setUpperLimit(double upperLimit)
 void Parameter::connectFrom(const AbsParameter *  source)
 {
   const Parameter *sp = source->parameter();
-  if (sp && sp->_sourceParameter) {
-    connectFrom(sp->_sourceParameter);
+  if (sp && *sp->_sourceParameter) {
+    *_sourceParameter=sp;
   }
   else {
-    _sourceParameter = source;
+    *_sourceParameter = source;
   }
 }
 

--- a/QatGenericFunctions/src/Parameter.cpp
+++ b/QatGenericFunctions/src/Parameter.cpp
@@ -151,6 +151,9 @@ Parameter::Parameter(const Parameter & right):
   _origin(&right),
   _sourceParameter(right._sourceParameter)
 {
+  //while (_origin) {
+  //  if (_origin->_origin) _origin=_origin->_origin; else break;
+  //}
 }
   
 const Parameter & Parameter::operator=(const Parameter &right) {
@@ -162,6 +165,10 @@ const Parameter & Parameter::operator=(const Parameter &right) {
     _origin=&right;
     _sourceParameter=right._sourceParameter;
   }
+  //  while (_origin) {
+  //  if (_origin->_origin) _origin=_origin->_origin; else break;
+  // }
+
   return *this;
 }
 

--- a/QatGenericFunctions/src/Parameter.cpp
+++ b/QatGenericFunctions/src/Parameter.cpp
@@ -81,7 +81,12 @@ void Parameter::setValue(double value)
 {
   if (*_sourceParameter) {
     std::cerr
-      << "Warning:  Parameter is connected.  Function has no effect."
+      << "Warning:  Parameter is connected.  setValue has no effect."
+      << std::endl;
+  }
+  else if (_origin) {
+    std::cerr
+      << "Warning:  Parameter is a copy.  setValue has no effect."
       << std::endl;
   }
   else {
@@ -95,7 +100,12 @@ void Parameter::setLowerLimit(double lowerLimit)
 
   if (*_sourceParameter) {
     std::cerr
-      << "Warning:  Parameter is connected.  Function has no effect."
+      << "Warning:  Parameter is connected.  setLowerLimit has no effect."
+      << std::endl;
+  }
+  else if (_origin) {
+    std::cerr
+      << "Warning:  Parameter is a copy.  setLowerLimit has no effect."
       << std::endl;
   }
   else {
@@ -107,7 +117,12 @@ void Parameter::setUpperLimit(double upperLimit)
 {
   if (*_sourceParameter) {
     std::cerr
-      << "Warning:  Parameter is connected.  Function has no effect."
+      << "Warning:  Parameter is connected.  setUpperLimit has no effect."
+      << std::endl;
+  }
+  else if (_origin) {
+    std::cerr
+      << "Warning:  Parameter is a copy. setUpperLimit has no effect."
       << std::endl;
   }
   else {

--- a/QatGenericFunctions/src/ParameterComposition.cpp
+++ b/QatGenericFunctions/src/ParameterComposition.cpp
@@ -27,25 +27,22 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterComposition)
 
-ParameterComposition::ParameterComposition(const AbsFunction *arg1, const AbsParameter *arg2):
+ParameterComposition::ParameterComposition(const std::shared_ptr<const AbsFunction> &arg1, const std::shared_ptr<const AbsParameter> & arg2):
   AbsParameter(),
-  _arg1(arg1->clone()),
-  _arg2(arg2->clone())
+  _arg1(arg1),
+  _arg2(arg2)
 {
-  if (arg2->parameter() && _arg2->parameter()) _arg2->parameter()->connectFrom(arg2->parameter());
 }
 
 ParameterComposition::ParameterComposition(const ParameterComposition & right) :
 AbsParameter(),
-_arg1(right._arg1->clone()),
-_arg2(right._arg2->clone())
+_arg1(right._arg1),
+_arg2(right._arg2)
 {}
 
 
 ParameterComposition::~ParameterComposition()
 {
-  delete _arg1;
-  delete _arg2;
 }
 
 

--- a/QatGenericFunctions/src/ParameterDifference.cpp
+++ b/QatGenericFunctions/src/ParameterDifference.cpp
@@ -26,25 +26,21 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterDifference)
 
-ParameterDifference::ParameterDifference(const AbsParameter *arg1, const AbsParameter *arg2):
-  _arg1(arg1->clone()),
-  _arg2(arg2->clone())
+ParameterDifference::ParameterDifference(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2):
+  _arg1(arg1),
+  _arg2(arg2)
 {
-  if (arg1->parameter() && _arg1->parameter()) _arg1->parameter()->connectFrom(arg1->parameter());
-  if (arg2->parameter() && _arg2->parameter()) _arg2->parameter()->connectFrom(arg2->parameter());
 }
 
 ParameterDifference::ParameterDifference(const ParameterDifference & right) :
 AbsParameter(),
-_arg1(right._arg1->clone()),
-_arg2(right._arg2->clone())
+_arg1(right._arg1),
+_arg2(right._arg2)
 {}
 
 
 ParameterDifference::~ParameterDifference()
 {
-  delete _arg1;
-  delete _arg2;
 }
 
 

--- a/QatGenericFunctions/src/ParameterDifference.cpp
+++ b/QatGenericFunctions/src/ParameterDifference.cpp
@@ -26,7 +26,7 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterDifference)
 
-ParameterDifference::ParameterDifference(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2):
+ParameterDifference::ParameterDifference(const std::shared_ptr<const AbsParameter> & arg1, const std::shared_ptr<const AbsParameter> & arg2):
   _arg1(arg1),
   _arg2(arg2)
 {

--- a/QatGenericFunctions/src/ParameterNegation.cpp
+++ b/QatGenericFunctions/src/ParameterNegation.cpp
@@ -26,21 +26,19 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterNegation)
 
-ParameterNegation::ParameterNegation(const AbsParameter *arg1):
-  _arg1(arg1->clone())
+ParameterNegation::ParameterNegation(std::shared_ptr<const AbsParameter> arg1):
+  _arg1(arg1)
 {
-  if (arg1->parameter() && _arg1->parameter()) _arg1->parameter()->connectFrom(arg1->parameter());
 }
 
 ParameterNegation::ParameterNegation(const ParameterNegation & right) :
 AbsParameter(),
-_arg1(right._arg1->clone())
+_arg1(right._arg1)
 {}
 
 
 ParameterNegation::~ParameterNegation()
 {
-  delete _arg1;
 }
 
 

--- a/QatGenericFunctions/src/ParameterNegation.cpp
+++ b/QatGenericFunctions/src/ParameterNegation.cpp
@@ -26,7 +26,7 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterNegation)
 
-ParameterNegation::ParameterNegation(std::shared_ptr<const AbsParameter> arg1):
+ParameterNegation::ParameterNegation(const std::shared_ptr<const AbsParameter> & arg1):
   _arg1(arg1)
 {
 }

--- a/QatGenericFunctions/src/ParameterProduct.cpp
+++ b/QatGenericFunctions/src/ParameterProduct.cpp
@@ -26,25 +26,21 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterProduct)
 
-ParameterProduct::ParameterProduct(const AbsParameter *arg1, const AbsParameter *arg2):
-  _arg1(arg1->clone()),
-  _arg2(arg2->clone())
+ParameterProduct::ParameterProduct(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2):
+  _arg1(arg1),
+  _arg2(arg2)
 {
-  if (arg1->parameter() && _arg1->parameter()) _arg1->parameter()->connectFrom(arg1->parameter());
-  if (arg2->parameter() && _arg2->parameter()) _arg2->parameter()->connectFrom(arg2->parameter());
 }
 
 ParameterProduct::ParameterProduct(const ParameterProduct & right) :
 AbsParameter(),
-_arg1(right._arg1->clone()),
-_arg2(right._arg2->clone())
+_arg1(right._arg1),
+_arg2(right._arg2)
 {}
 
 
 ParameterProduct::~ParameterProduct()
 {
-  delete _arg1;
-  delete _arg2;
 }
 
 

--- a/QatGenericFunctions/src/ParameterProduct.cpp
+++ b/QatGenericFunctions/src/ParameterProduct.cpp
@@ -26,7 +26,7 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterProduct)
 
-ParameterProduct::ParameterProduct(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2):
+ParameterProduct::ParameterProduct(const std::shared_ptr<const AbsParameter> & arg1, const std::shared_ptr<const AbsParameter> & arg2):
   _arg1(arg1),
   _arg2(arg2)
 {

--- a/QatGenericFunctions/src/ParameterQuotient.cpp
+++ b/QatGenericFunctions/src/ParameterQuotient.cpp
@@ -26,25 +26,21 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterQuotient)
 
-ParameterQuotient::ParameterQuotient(const AbsParameter *arg1, const AbsParameter *arg2):
-  _arg1(arg1->clone()),
-  _arg2(arg2->clone())
+ParameterQuotient::ParameterQuotient(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2):
+  _arg1(arg1),
+  _arg2(arg2)
 {
-  if (arg1->parameter() && _arg1->parameter()) _arg1->parameter()->connectFrom(arg1->parameter());
-  if (arg2->parameter() && _arg2->parameter()) _arg2->parameter()->connectFrom(arg2->parameter());
 }
 
 ParameterQuotient::ParameterQuotient(const ParameterQuotient & right) :
 AbsParameter(),
-_arg1(right._arg1->clone()),
-_arg2(right._arg2->clone())
+_arg1(right._arg1),
+_arg2(right._arg2)
 {}
 
 
 ParameterQuotient::~ParameterQuotient()
 {
-  delete _arg1;
-  delete _arg2;
 }
 
 

--- a/QatGenericFunctions/src/ParameterQuotient.cpp
+++ b/QatGenericFunctions/src/ParameterQuotient.cpp
@@ -26,7 +26,7 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterQuotient)
 
-ParameterQuotient::ParameterQuotient(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2):
+ParameterQuotient::ParameterQuotient(const std::shared_ptr<const AbsParameter> & arg1, const std::shared_ptr<const AbsParameter> & arg2):
   _arg1(arg1),
   _arg2(arg2)
 {

--- a/QatGenericFunctions/src/ParameterSum.cpp
+++ b/QatGenericFunctions/src/ParameterSum.cpp
@@ -26,25 +26,21 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterSum)
 
-ParameterSum::ParameterSum(const AbsParameter *arg1, const AbsParameter *arg2):
-  _arg1(arg1->clone()),
-  _arg2(arg2->clone())
+ParameterSum::ParameterSum(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2):
+  _arg1(arg1),
+  _arg2(arg2)
 {
-  if (arg1->parameter() && _arg1->parameter()) _arg1->parameter()->connectFrom(arg1->parameter());
-  if (arg2->parameter() && _arg2->parameter()) _arg2->parameter()->connectFrom(arg2->parameter());
 }
 
 ParameterSum::ParameterSum(const ParameterSum & right) :
 AbsParameter(),
-_arg1(right._arg1->clone()),
-_arg2(right._arg2->clone())
+_arg1(right._arg1),
+_arg2(right._arg2)
 {}
 
 
 ParameterSum::~ParameterSum()
 {
-  delete _arg1;
-  delete _arg2;
 }
 
 

--- a/QatGenericFunctions/src/ParameterSum.cpp
+++ b/QatGenericFunctions/src/ParameterSum.cpp
@@ -26,7 +26,7 @@
 namespace Genfun {
 PARAMETER_OBJECT_IMP(ParameterSum)
 
-ParameterSum::ParameterSum(std::shared_ptr<const AbsParameter> arg1, std::shared_ptr<const AbsParameter> arg2):
+ParameterSum::ParameterSum(const std::shared_ptr<const AbsParameter> & arg1, const std::shared_ptr<const AbsParameter> & arg2):
   _arg1(arg1),
   _arg2(arg2)
 {

--- a/QatGenericFunctions/src/Pi.cpp
+++ b/QatGenericFunctions/src/Pi.cpp
@@ -84,7 +84,10 @@ Derivative Pi::partial(unsigned int index) const {
     }
     fPrime.accumulate(_fcn[i]->partial(index)*subproductI);
   }
-  return Derivative(&fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 

--- a/QatGenericFunctions/src/Power.cpp
+++ b/QatGenericFunctions/src/Power.cpp
@@ -83,11 +83,13 @@ Derivative Power::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Power:  partial derivative index out of range");
   if (_asInteger) {
     const AbsFunction & fPrime = _intPower*Power(_intPower-1);
-    return Derivative(&fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
   else {
     const AbsFunction & fPrime = _doublePower*Power(_doublePower-1);
-    return Derivative(&fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
   }
 
 }

--- a/QatGenericFunctions/src/Sigma.cpp
+++ b/QatGenericFunctions/src/Sigma.cpp
@@ -75,7 +75,9 @@ Derivative Sigma::partial(unsigned int index) const {
   for (size_t i=0;i<_fcn.size();i++) {
     fPrime.accumulate(_fcn[i]->partial(index));
   }
-  return Derivative(&fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
 }
 
 

--- a/QatGenericFunctions/src/Sin.cpp
+++ b/QatGenericFunctions/src/Sin.cpp
@@ -47,7 +47,9 @@ double Sin::operator() (double x) const {
 Derivative Sin::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Sin: partial derivative index out of range");
   const AbsFunction & fPrime = Cos();
-  return Derivative(& fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/Sinh.cpp
+++ b/QatGenericFunctions/src/Sinh.cpp
@@ -47,7 +47,8 @@ double Sinh::operator() (double x) const {
 Derivative Sinh::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Sinh: partial derivative index out of range");
   const AbsFunction & fPrime = Cosh();
-  return Derivative(& fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/Sqrt.cpp
+++ b/QatGenericFunctions/src/Sqrt.cpp
@@ -44,7 +44,10 @@ double Sqrt::operator() (double x) const {
 Derivative Sqrt::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Sqrt: partial derivative index out of range");
   const AbsFunction & fPrime = (0.5)/Sqrt();
-  return Derivative(&fPrime);
+  
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 

--- a/QatGenericFunctions/src/Square.cpp
+++ b/QatGenericFunctions/src/Square.cpp
@@ -47,7 +47,8 @@ Derivative Square::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Square: partial derivative index out of range"); 
   Variable x;
   const AbsFunction & fPrime = 2*x;
-  return Derivative(&fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
 }
 
 

--- a/QatGenericFunctions/src/Tan.cpp
+++ b/QatGenericFunctions/src/Tan.cpp
@@ -49,7 +49,9 @@ Derivative Tan::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Tan: partial derivative index out of range");
 
   const AbsFunction & fPrime = 1.0/Cos()/Cos();
-  return Derivative(& fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/Tanh.cpp
+++ b/QatGenericFunctions/src/Tanh.cpp
@@ -49,7 +49,10 @@ Derivative Tanh::partial(unsigned int index) const {
   if (index!=0) throw std::range_error("Tanh: partial derivative index out of range");
 
   const AbsFunction & fPrime = 1.0/Cosh()/Cosh();
-  return Derivative(& fPrime);
+
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/TchebyshevPolynomial.cpp
+++ b/QatGenericFunctions/src/TchebyshevPolynomial.cpp
@@ -22,6 +22,7 @@
 
 #include "QatGenericFunctions/TchebyshevPolynomial.h"
 #include "QatGenericFunctions/Variable.h"
+#include "QatGenericFunctions/FixedConstant.h"
 #include "QatGenericFunctions/Power.h"
 #include <stdexcept>
 #include <cmath>
@@ -77,7 +78,11 @@ namespace Genfun {
 
   Derivative TchebyshevPolynomial::partial(unsigned int index) const {
     if (index!=0) throw std::range_error("TchebyshevPolynomial: partial derivative index out of range");
-    if (_n==0) return 0;
+    if (_n==0) {
+      FixedConstant fPrime(0.0);
+      std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+      return Derivative(deriv);
+    };
     
     const double norm=_normType==STD ? 1.0:sqrt(M_PI);
     
@@ -87,7 +92,9 @@ namespace Genfun {
       norm*_n*TchebyshevPolynomial(_n-1, SecondKind, STD)
       :
       norm*(((_n+1)*TchebyshevPolynomial(_n+1,FirstKind, STD)-X*TchebyshevPolynomial(_n,SecondKind, STD))/(X+1)/(X-1));
-    return Derivative(& fPrime);
+    std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+    return Derivative(deriv);
+
   }
 
 

--- a/QatGenericFunctions/src/Theta.cpp
+++ b/QatGenericFunctions/src/Theta.cpp
@@ -45,7 +45,9 @@ double Theta::operator() (double x) const {
 Derivative Theta::partial(unsigned int index) const {
   if (index!=0) throw std::runtime_error("Theta::Partial: index out of range");
   const AbsFunction & fPrime = FixedConstant(0.0);
-  return Derivative(& fPrime);
+  std::shared_ptr<const AbsFunction> deriv{fPrime.clone()};
+  return Derivative(deriv);
+  
 }
 
 } // namespace Genfun

--- a/QatGenericFunctions/src/Variable.cpp
+++ b/QatGenericFunctions/src/Variable.cpp
@@ -59,7 +59,8 @@ unsigned int Variable::index() const {
 Derivative Variable::partial(unsigned int mindex) const {
   double kroneckerDelta = mindex==_selectionIndex ? 1.0 : 0.0;
   KVector vec(_dimensionality,kroneckerDelta);
-  return Derivative(&vec);
+  std::shared_ptr<const AbsFunction> deriv{vec.clone()};
+  return Derivative(deriv);
 }
 
 unsigned int Variable::dimensionality() const {

--- a/QatGenericFunctions/src/VoigtDistribution.cpp
+++ b/QatGenericFunctions/src/VoigtDistribution.cpp
@@ -92,8 +92,8 @@ FUNCTION_OBJECT_IMP(VoigtDistribution)
 
 
 VoigtDistribution::VoigtDistribution():
-  _delta ("delta", 5, 0,   100),
-  _sigma("sigma",  5, 0,   100)
+_delta (new Parameter("delta", 5, 0,   100)),
+  _sigma(new Parameter("sigma",  5, 0,   100))
 {}
 
   VoigtDistribution::VoigtDistribution(const VoigtDistribution & right):
@@ -107,8 +107,8 @@ VoigtDistribution::~VoigtDistribution() {
 }
 
 double VoigtDistribution::operator() (double x) const {
-  double G=_delta.getValue();
-  double s=_sigma.getValue();
+  double G=_delta->getValue();
+  double s=_sigma->getValue();
   static const double sqrt2=sqrt(2.0);
   static const double sqrt2PI=sqrt(2.0*M_PI);
   static const std::complex<double> I(0,1);
@@ -123,11 +123,11 @@ double VoigtDistribution::operator() (double x) const {
 
 
 Parameter & VoigtDistribution::delta() {
-  return _delta;
+  return *_delta;
 }
 
 Parameter & VoigtDistribution::sigma() {
-  return _sigma;
+  return *_sigma;
 }
 
 

--- a/QatInventorWidgets/CMakeLists.txt
+++ b/QatInventorWidgets/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(QatInventorWidgets VERSION ${Qat_VERSION} LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file( GLOB SOURCES src/*.cpp )

--- a/QatPlotWidgets/CMakeLists.txt
+++ b/QatPlotWidgets/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(QatPlotWidgets VERSION ${Qat_VERSION} LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file( GLOB SOURCES src/*.cpp src/*.qrc )

--- a/QatPlotting/CMakeLists.txt
+++ b/QatPlotting/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(QatPlotting VERSION ${Qat_VERSION} LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
+set(CMAKE_BUILD_TYPE Release)
 file( GLOB SOURCES src/*.cpp )
 file( GLOB HEADERS QatPlotting/*.h QatPlotting/*.icc )
 

--- a/QatProject/CMakeLists.txt
+++ b/QatProject/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(QatProject VERSION ${Qat_VERSION} LANGUAGES CXX)
 include (GNUInstallDirs)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file( GLOB SOURCES *.cpp )

--- a/QatProject/TEMPLATES/qt.pro
+++ b/QatProject/TEMPLATES/qt.pro
@@ -9,7 +9,7 @@ mac {
 }
 
 
-CONFIG += qt debug c++17
+CONFIG += qt debug c++20
 
 # Input
 SOURCES += *.cpp

--- a/QatProject/TEMPLATES/templateFunction.cpp
+++ b/QatProject/TEMPLATES/templateFunction.cpp
@@ -25,6 +25,7 @@ namespace Genfun {
   // Partial Derivative
   Derivative <Function>::partial(unsigned int index) const {
     const AbsFunction & fPrime=FixedConstant(0);
-    return Derivative(&fPrime);
+    std::shared_ptr<const AbsFunction> deriv(fPrime.clone());
+    return Derivative(deriv);
   }
 }

--- a/Qhfd/CMakeLists.txt
+++ b/Qhfd/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(QHDF5 VERSION ${Qat_VERSION} LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file( GLOB SOURCES src/*.cpp )

--- a/Qoot/CMakeLists.txt
+++ b/Qoot/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Set up the project.
 cmake_minimum_required( VERSION 3.10 )
-set  (CMAKE_CXX_STANDARD 17)
+set  (CMAKE_CXX_STANDARD 20)
 project( "QOOT" VERSION ${Qat_VERSION} LANGUAGES CXX )
 set    ( CMAKE_BUILD_TYPE RelWithDebInfo )
 

--- a/cmake/Qat-version.cmake
+++ b/cmake/Qat-version.cmake
@@ -1,3 +1,3 @@
-set( Qat_VERSION "5.0.0" CACHE STRING
+set( Qat_VERSION "6.0.0" CACHE STRING
     "Version of the Qat project" )
 


### PR DESCRIPTION
This is a major revision of the qat libraries.  The main (overdue) improvement is that deep copies of binary expressions trees are avoided in GeoGenericFunctions; instead of cloning entire subtrees of arithematic expressions, shared pointers are used.  Additionally, the C++ version used in c++20. Expect performance improvements. 

