### PR TITLE
Qat clients can now use cmake to build against qat packages. 

### DIFF
--- a/QatDataAnalysis/CMakeLists.txt
+++ b/QatDataAnalysis/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10.0)
 
 project(QatDataAnalysis VERSION ${Qat_VERSION} LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -9,6 +11,9 @@ file( GLOB SOURCES src/*.cpp )
 file( GLOB HEADERS QatDataAnalysis/*.h QatDataAnalysis/*.icc )
 
 find_package(Eigen3 REQUIRED)
+
+include(CMakePackageConfigHelpers)
+set(QAT_FIND_DEPENDENCIES "find_dependency(Eigen3)\nfind_dependency(QatGenericFunctions)")
 
 add_library( QatDataAnalysis SHARED ${HEADERS} ${SOURCES} )
 target_link_libraries( QatDataAnalysis PUBLIC Eigen3::Eigen QatGenericFunctions )
@@ -32,6 +37,31 @@ install( FILES ${HEADERS}
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QatDataAnalysis
    COMPONENT Development )
 
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/../cmake/QatPackageConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(EXPORT ${PROJECT_NAME}-export
+    FILE "${PROJECT_NAME}Targets.cmake"
+    NAMESPACE "Qat::"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
 
 configure_file (pkgconfig/QatDataAnalysis.pc.in pkgconfig/QatDataAnalysis.pc ) 
 

--- a/QatDataModeling/CMakeLists.txt
+++ b/QatDataModeling/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10.0)
 
 project(QatDataModeling VERSION ${Qat_VERSION} LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -9,6 +11,9 @@ file( GLOB SOURCES src/*.cpp Minuit2/src/*.cxx)
 file( GLOB HEADERS QatDataModeling/*.h QatDataModeling/*.icc )
 
 find_package(Eigen3 REQUIRED)
+
+include(CMakePackageConfigHelpers)
+set(QAT_FIND_DEPENDENCIES "find_dependency(Eigen3)\nfind_dependency(QatDataAnalysis)\nfind_dependency(QatGenericFunctions)")
 
 add_library( QatDataModeling SHARED ${HEADERS} ${SOURCES} )
 target_link_libraries( QatDataModeling PUBLIC Eigen3::Eigen QatDataAnalysis QatGenericFunctions )
@@ -31,6 +36,32 @@ install(TARGETS QatDataModeling
 install( FILES ${HEADERS}
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QatDataModeling
    COMPONENT Development )
+
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/../cmake/QatPackageConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(EXPORT ${PROJECT_NAME}-export
+    FILE "${PROJECT_NAME}Targets.cmake"
+    NAMESPACE "Qat::"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
 
 
 configure_file (pkgconfig/QatDataModeling.pc.in pkgconfig/QatDataModeling.pc ) 

--- a/QatGenericFunctions/CMakeLists.txt
+++ b/QatGenericFunctions/CMakeLists.txt
@@ -1,6 +1,8 @@
-cmake_minimum_required(VERSION 3.10.0)
+cmake_minimum_required(VERSION 4.4.0)
 
 project(QatGenericFunctions VERSION ${Qat_VERSION} LANGUAGES CXX)
+
+include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -10,6 +12,9 @@ file( GLOB SOURCES src/*.cpp )
 file( GLOB HEADERS QatGenericFunctions/*.h QatGenericFunctions/*.icc )
 
 find_package(Eigen3 REQUIRED)
+
+include(CMakePackageConfigHelpers)
+set(QAT_FIND_DEPENDENCIES "find_dependency(Eigen3)")
 
 add_library( QatGenericFunctions SHARED ${HEADERS} ${SOURCES} )
 target_link_libraries( QatGenericFunctions PUBLIC Eigen3::Eigen )
@@ -32,6 +37,33 @@ install(TARGETS QatGenericFunctions
 install( FILES ${HEADERS}
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QatGenericFunctions
    COMPONENT Development )
+
+
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/../cmake/QatPackageConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(EXPORT ${PROJECT_NAME}-export
+    FILE "${PROJECT_NAME}Targets.cmake"
+    NAMESPACE "Qat::"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
 
 configure_file (pkgconfig/QatGenericFunctions.pc.in pkgconfig/QatGenericFunctions.pc ) 
 

--- a/QatGenericFunctions/CMakeLists.txt
+++ b/QatGenericFunctions/CMakeLists.txt
@@ -6,7 +6,7 @@ include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE Release)
 
 file( GLOB SOURCES src/*.cpp )
 file( GLOB HEADERS QatGenericFunctions/*.h QatGenericFunctions/*.icc )

--- a/QatGenericFunctions/CMakeLists.txt
+++ b/QatGenericFunctions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.4.0)
+cmake_minimum_required(VERSION 4.0.0)
 
 project(QatGenericFunctions VERSION ${Qat_VERSION} LANGUAGES CXX)
 

--- a/QatInventorWidgets/CMakeLists.txt
+++ b/QatInventorWidgets/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10.0)
 
 project(QatInventorWidgets VERSION ${Qat_VERSION} LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -23,6 +25,9 @@ find_package(Qt${QT_VERSION} COMPONENTS Widgets PrintSupport Svg REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Coin REQUIRED)
 find_package(SoQt REQUIRED)
+
+include(CMakePackageConfigHelpers)
+set(QAT_FIND_DEPENDENCIES "find_dependency(Eigen3)\nfind_dependency(Qt${QT_VERSION} COMPONENTS Widgets PrintSupport Svg)\nfind_dependency(Coin)\nfind_dependency(SoQt)\nfind_dependency(QatDataAnalysis)\nfind_dependency(QatGenericFunctions)\nfind_dependency(QatPlotting)\nfind_dependency(QatPlotWidgets)")
 
 
 add_library( QatInventorWidgets SHARED ${HEADERS} ${SOURCES} ${FORMS} )
@@ -47,7 +52,31 @@ install( FILES ${HEADERS}
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QatInventorWidgets
    COMPONENT Development )
 
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/../cmake/QatPackageConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
 
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(EXPORT ${PROJECT_NAME}-export
+    FILE "${PROJECT_NAME}Targets.cmake"
+    NAMESPACE "Qat::"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
 
 
 configure_file (pkgconfig/QatInventorWidgets.pc.in pkgconfig/QatInventorWidgets.pc ) 

--- a/QatPlotWidgets/CMakeLists.txt
+++ b/QatPlotWidgets/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10.0)
 
 project(QatPlotWidgets VERSION ${Qat_VERSION} LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -22,6 +24,8 @@ endif()
 find_package(Qt${QT_VERSION} COMPONENTS Widgets PrintSupport Svg REQUIRED)
 find_package(Eigen3 REQUIRED)
 
+include(CMakePackageConfigHelpers)
+set(QAT_FIND_DEPENDENCIES "find_dependency(Eigen3)\nfind_dependency(Qt${QT_VERSION} COMPONENTS Widgets PrintSupport Svg)\nfind_dependency(QatDataAnalysis)\nfind_dependency(QatGenericFunctions)\nfind_dependency(QatPlotting)")
 
 
 add_library( QatPlotWidgets SHARED ${HEADERS} ${SOURCES} ${FORMS} )
@@ -46,6 +50,31 @@ install( FILES ${HEADERS}
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QatPlotWidgets
    COMPONENT Development )
 
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/../cmake/QatPackageConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(EXPORT ${PROJECT_NAME}-export
+    FILE "${PROJECT_NAME}Targets.cmake"
+    NAMESPACE "Qat::"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
 
 
 configure_file (pkgconfig/QatPlotWidgets.pc.in pkgconfig/QatPlotWidgets.pc ) 

--- a/QatPlotting/CMakeLists.txt
+++ b/QatPlotting/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10.0)
 
 project(QatPlotting VERSION ${Qat_VERSION} LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_BUILD_TYPE Release)
@@ -21,6 +23,8 @@ endif()
 find_package(Qt${QT_VERSION} COMPONENTS Widgets REQUIRED)
 find_package(Eigen3 REQUIRED)
 
+include(CMakePackageConfigHelpers)
+set(QAT_FIND_DEPENDENCIES "find_dependency(Eigen3)\nfind_dependency(Qt${QT_VERSION} COMPONENTS Widgets)\nfind_dependency(QatDataAnalysis)\nfind_dependency(QatGenericFunctions)")
 
 
 add_library( QatPlotting SHARED ${HEADERS} ${SOURCES} )
@@ -45,6 +49,31 @@ install( FILES ${HEADERS}
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QatPlotting
    COMPONENT Development )
 
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/../cmake/QatPackageConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(EXPORT ${PROJECT_NAME}-export
+    FILE "${PROJECT_NAME}Targets.cmake"
+    NAMESPACE "Qat::"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)
 
 configure_file (pkgconfig/QatPlotting.pc.in pkgconfig/QatPlotting.pc ) 
 

--- a/QatProject/QatProjectForm.cpp
+++ b/QatProject/QatProjectForm.cpp
@@ -98,16 +98,27 @@ void QatProjectForm::createProject() {
   {
     iret=system ((std::string("cp ")+shareDirName+std::string("/qat/templates/qt.pro ") + directoryName+"/src").c_str()); 
     if (iret!=0) throw std::runtime_error("Error installing qt.pro into local directory");
+
+    iret=system ((std::string("cp ")+shareDirName+std::string("/qat/templates/CMakeLists.txt ") + directoryName).c_str()); 
+    if (iret!=0) throw std::runtime_error("Error installing CMakeLists.txt into local directory");
+
   }
 #ifdef __APPLE__
   {
     iret=system (("sed -i .orig s/\"<app>\"/" + programName + "/g " + directoryName + "/src/qt.pro").c_str());
     if (iret!=0) throw std::runtime_error("Error patching qt.pro in local directory");
+
+    iret=system (("sed -i .orig s/\"<app>\"/" + programName + "/g " + directoryName + "/CMakeLists.txt").c_str());
+    if (iret!=0) throw std::runtime_error("Error patching CMakeLists.txt in local directory");
+
   }
 #else
   {
     iret=system (("sed -i  s/\\<app\\>/" + programName + "/g " + directoryName + "/src/qt.pro").c_str());
     if (iret!=0) throw std::runtime_error("Error patching qt.pro in local directory.");
+
+    iret=system (("sed -i  s/\\<app\\>/" + programName + "/g " + directoryName + "/CMakeLists.txt").c_str());
+    if (iret!=0) throw std::runtime_error("Error patching CMakeLists.txt in local directory.");
   }
 #endif
   // There are eight templates.  Choose one of them:

--- a/QatProject/TEMPLATES/CMakeLists.txt
+++ b/QatProject/TEMPLATES/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.16)
+set (target <app>)
+project(${target} LANGUAGES CXX)
+
+set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(QatPlotWidgets      REQUIRED)
+find_package(GSL                 REQUIRED)
+
+set(CMAKE_MACOSX_RPATH 1)
+set(CMAKE_BUILD_RPATH "${QatPlotWidgets_DIR}/../..")
+
+file(GLOB SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+
+add_executable(${target} ${SOURCES})
+target_link_libraries(${target} PRIVATE QatPlotWidgets QatPlotting
+  QatDataModeling QatDataAnalysis QatGenericFunctions
+  Qt6::Widgets Qt6::Core
+  Eigen3::Eigen GSL::gsl)
+

--- a/QatProject/testprogram
+++ b/QatProject/testprogram
@@ -26,7 +26,7 @@ EOF
 target=`basename $name .cpp`
 
 
-echo CXXFLAGS= "-std=c++11 -g -O0 -gdwarf-2" > Makefile
+echo CXXFLAGS= "-std=c++20 -g -O0 -gdwarf-2" > Makefile
 echo all:${target} >> Makefile
 echo clean: >> Makefile
 echo -e  "\trm -f *.o *~ ${target}" >> Makefile

--- a/cmake/QatPackageConfig.cmake.in
+++ b/cmake/QatPackageConfig.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+@QAT_FIND_DEPENDENCIES@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+#check_required_components(@PROJECT_NAME@)


### PR DESCRIPTION
The CMake configuration files have been added to the project so that cmake can be used to build all qat-based executables.  

Also, the qat-project command which initializes a directory and a skeleton application has been modified so that it adds a CMakeLists.txt to the skeleton application.  With this merge, both a qt.pro and a CMakeLists.txt file are generated. This is allows either a qmake or a cmake build.  

We note that guidance from Qt is that qmake should be used only for legacy code, new projects should use cmake.
So the qt option will be removed, ultimately. 